### PR TITLE
커뮤니티 퍼즐 리스트 사용성 개선

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,9 +6,11 @@
  */
 
 import React from 'react';
+import { StatusBar, StyleSheet } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator, NativeStackHeaderProps } from '@react-navigation/native-stack';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import './src/locales/i18n.ts';
 import useAuthStore from './src/store/useAuthStore.ts';
 import useInitializeApp from './src/hooks/useInitializeApp/index.ts';
@@ -31,7 +33,6 @@ import CreateCommunityPuzzle from './src/screens/CreateCommunityPuzzle/index.tsx
 import RankedPuzzleSolve from './src/screens/RankedPuzzleSolve/index.tsx';
 import PuzzleReview from './src/screens/PuzzleReview/index.tsx';
 import AnswerCommunityPuzzle from './src/screens/CreateCommunityPuzzle/AnswerCommunityPuzzle/index.tsx';
-import { StatusBar } from 'react-native';
 import theme from './src/styles/theme.ts';
 
 const Stack = createNativeStackNavigator();
@@ -47,100 +48,116 @@ function App(): React.JSX.Element | null {
   }
 
   return (
-    <SafeAreaProvider>
-      <NavigationContainer>
-        <AppWrapper>
-          <StatusBar
-            barStyle={'dark-content'}
-            backgroundColor={theme.color['gray/grayBG']}
-            translucent={false}
-          />
+    <GestureHandlerRootView style={styles.root}>
+      <SafeAreaProvider>
+        <NavigationContainer>
+          <AppWrapper>
+            <StatusBar
+              barStyle={'dark-content'}
+              backgroundColor={theme.color['gray/grayBG']}
+              translucent={false}
+            />
 
-          <Stack.Navigator
-            screenOptions={{
-              header: renderCustomHeader,
-            }}>
-            {accessToken ? (
-              <>
-                <Stack.Screen name="Home" component={Home} options={{ title: 'common.appName' }} />
-                <Stack.Screen
-                  name="MyPuzzles"
-                  component={MyPuzzles}
-                  options={{ title: 'common.myPuzzle' }}
-                />
-                <Stack.Screen
-                  name="LikedPuzzles"
-                  component={LikedPuzzles}
-                  options={{ title: 'common.likes' }}
-                />
-                <Stack.Screen
-                  name="Ranking"
-                  component={Ranking}
-                  options={{ title: 'common.ranking' }}
-                />
-                <Stack.Screen
-                  name="TrainingPacks"
-                  component={TrainingPacks}
-                  options={{ title: 'home.trainingPuzzle' }}
-                />
-                <Stack.Screen
-                  name="TrainingPuzzles"
-                  component={TrainingPuzzles}
-                  options={{ title: 'home.trainingPuzzle' }}
-                />
-                <Stack.Screen
-                  name="TrainingPuzzleSolve"
-                  component={TrainingPuzzleSolve}
-                  options={{ title: 'home.trainingPuzzle' }}
-                />
-                <Stack.Screen
-                  name="TrainingPuzzleReview"
-                  component={PuzzleReview}
-                  options={{ title: 'home.trainingPuzzle' }}
-                />
-                <Stack.Screen
-                  name="CommunityPuzzles"
-                  component={CommunityPuzzles}
-                  options={{ title: 'home.communityPuzzle' }}
-                />
-                <Stack.Screen
-                  name="CommunityPuzzleSolve"
-                  component={CommunityPuzzleSolve}
-                  options={{ title: 'home.communityPuzzle' }}
-                />
-                <Stack.Screen
-                  name="CommunityPuzzleReview"
-                  component={PuzzleReview}
-                  options={{ title: 'home.communityPuzzle' }}
-                />
-                <Stack.Screen
-                  name="CreateCommunityPuzzle"
-                  component={CreateCommunityPuzzle}
-                  options={{ title: 'home.communityPuzzle' }}
-                />
-                <Stack.Screen
-                  name="AnswerCommunityPuzzle"
-                  component={AnswerCommunityPuzzle}
-                  options={{ title: 'home.communityPuzzle' }}
-                />
-                <Stack.Screen
-                  name="RankedPuzzleSolve"
-                  component={RankedPuzzleSolve}
-                  options={{ title: 'home.rankingPuzzle' }}
-                />
-              </>
-            ) : (
-              <>
-                <Stack.Screen name="Signin" component={Signin} options={{ headerShown: false }} />
-                <Stack.Screen name="Signup" component={Signup} options={{ title: 'auth.signup' }} />
-              </>
-            )}
-          </Stack.Navigator>
-        </AppWrapper>
-        <Toast config={toastConfig} />
-      </NavigationContainer>
-    </SafeAreaProvider>
+            <Stack.Navigator
+              screenOptions={{
+                header: renderCustomHeader,
+              }}>
+              {accessToken ? (
+                <>
+                  <Stack.Screen
+                    name="Home"
+                    component={Home}
+                    options={{ title: 'common.appName' }}
+                  />
+                  <Stack.Screen
+                    name="MyPuzzles"
+                    component={MyPuzzles}
+                    options={{ title: 'common.myPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="LikedPuzzles"
+                    component={LikedPuzzles}
+                    options={{ title: 'common.likes' }}
+                  />
+                  <Stack.Screen
+                    name="Ranking"
+                    component={Ranking}
+                    options={{ title: 'common.ranking' }}
+                  />
+                  <Stack.Screen
+                    name="TrainingPacks"
+                    component={TrainingPacks}
+                    options={{ title: 'home.trainingPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="TrainingPuzzles"
+                    component={TrainingPuzzles}
+                    options={{ title: 'home.trainingPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="TrainingPuzzleSolve"
+                    component={TrainingPuzzleSolve}
+                    options={{ title: 'home.trainingPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="TrainingPuzzleReview"
+                    component={PuzzleReview}
+                    options={{ title: 'home.trainingPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="CommunityPuzzles"
+                    component={CommunityPuzzles}
+                    options={{ title: 'home.communityPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="CommunityPuzzleSolve"
+                    component={CommunityPuzzleSolve}
+                    options={{ title: 'home.communityPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="CommunityPuzzleReview"
+                    component={PuzzleReview}
+                    options={{ title: 'home.communityPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="CreateCommunityPuzzle"
+                    component={CreateCommunityPuzzle}
+                    options={{ title: 'home.communityPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="AnswerCommunityPuzzle"
+                    component={AnswerCommunityPuzzle}
+                    options={{ title: 'home.communityPuzzle' }}
+                  />
+                  <Stack.Screen
+                    name="RankedPuzzleSolve"
+                    component={RankedPuzzleSolve}
+                    options={{ title: 'home.rankingPuzzle' }}
+                  />
+                </>
+              ) : (
+                <>
+                  <Stack.Screen name="Signin" component={Signin} options={{ headerShown: false }} />
+                  <Stack.Screen
+                    name="Signup"
+                    component={Signup}
+                    options={{ title: 'auth.signup' }}
+                  />
+                </>
+              )}
+            </Stack.Navigator>
+          </AppWrapper>
+          <Toast config={toastConfig} />
+        </NavigationContainer>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
   );
 }
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});
 
 export default App;

--- a/src/components/common/CustomModal/index.tsx
+++ b/src/components/common/CustomModal/index.tsx
@@ -61,7 +61,7 @@ export const MODAL_TEXTS = {
   COMMUNITY_PUZZLE_FAILURE: {
     TITLE: 'modal.communityPuzzleFailure.title',
     BODY: 'modal.communityPuzzleFailure.message',
-    FOOTER: 'modal.communityPuzzleFailure.confirm',
+    FOOTER: ['modal.communityPuzzleFailure.cancel', 'modal.communityPuzzleFailure.confirm'],
   },
   VALIDATION_COMPLETE: {
     TITLE: 'modal.validationComplete.title',

--- a/src/components/common/InfiniteScrollList/index.tsx
+++ b/src/components/common/InfiniteScrollList/index.tsx
@@ -1,9 +1,10 @@
 /* eslint-disable react/no-unstable-nested-components */
 /* eslint-disable react-native/no-inline-styles */
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react';
 import { ActivityIndicator, FlatList, FlatListProps, View } from 'react-native';
 import theme from '../../../styles/theme';
 import { showBottomToast } from '../Toast/toastMessage';
+import { RefreshControl } from 'react-native-gesture-handler';
 
 export interface ApiCallParams {
   id?: number | null;
@@ -29,82 +30,148 @@ interface InfiniteScrollListProps<T>
   ListEmptyComponent?: React.ReactElement | null;
 }
 
-const InfiniteScrollList = <T,>({
-  apiCall,
-  renderItem,
-  keyExtractor,
-  pageSize = 10,
-  defaultParams,
-  onEndReachedThreshold = 0.6,
-  ListEmptyComponent,
-  ...flatListProps
-}: InfiniteScrollListProps<T>) => {
-  const [data, setData] = useState<T[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-  const [cursorId, setCursorId] = useState<number | null>(null);
+export interface InfiniteScrollListRef<T> {
+  updateItem: (itemId: number, updater: (prevItem: T) => T) => void;
+  removeItem: (id: number) => void;
+}
 
-  const fetchData = useCallback(async () => {
-    if (loading || !hasMore) {
-      return;
-    }
+const InfiniteScrollList = forwardRef<InfiniteScrollListRef<any>, InfiniteScrollListProps<any>>(
+  (
+    {
+      apiCall,
+      renderItem,
+      keyExtractor,
+      pageSize = 10,
+      defaultParams,
+      onEndReachedThreshold = 0.6,
+      ListEmptyComponent,
+      ...flatListProps
+    },
+    ref,
+  ) => {
+    const [data, setData] = useState<any[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [refreshing, setRefreshing] = useState(false);
+    const [hasMore, setHasMore] = useState(true);
+    const [cursorId, setCursorId] = useState<number | null>(null);
 
-    setLoading(true);
-    try {
-      const fetched = await apiCall({
-        ...defaultParams,
-        id: cursorId,
-        size: pageSize,
-      });
+    useImperativeHandle(ref, () => ({
+      updateItem: (itemId: number, updater: (prevItem: any) => any) => {
+        setData((prevData) =>
+          prevData.map((item) => {
+            if (String(item.id) === String(itemId)) {
+              return updater(item); // ID가 같으면 업데이트 함수 실행
+            }
+            return item;
+          }),
+        );
+      },
+      removeItem: (id: number) => {
+        setData((prevData) => prevData.filter((item) => item.id !== id));
+      },
+    }));
 
-      setData((prev) => [...prev, ...fetched]);
-      setHasMore(fetched.length === pageSize);
-
-      if (fetched.length > 0) {
-        const last = fetched[fetched.length - 1] as any;
-        setCursorId(last.id ?? null);
+    const fetchData = useCallback(async () => {
+      if (loading || !hasMore || refreshing) {
+        return;
       }
-    } catch (err) {
-      showBottomToast('error', '리스트 불러오기 오류'); // TODO: locales
-    } finally {
-      setLoading(false);
-    }
-  }, [apiCall, cursorId, defaultParams, hasMore, loading, pageSize]);
 
-  useEffect(() => {
-    setData([]);
-    setHasMore(true);
-    setCursorId(null);
-  }, [defaultParams, pageSize]);
+      setLoading(true);
+      try {
+        const fetched = await apiCall({
+          ...defaultParams,
+          id: cursorId,
+          size: pageSize,
+        });
 
-  useEffect(() => {
-    if (cursorId === null) {
-      fetchData();
-    }
-  }, [cursorId, fetchData]);
+        setData((prev) => [...prev, ...fetched]);
+        setHasMore(fetched.length === pageSize);
 
-  const renderFooter = () =>
-    loading ? (
-      <ActivityIndicator color={theme.color['gray/gray300']} style={{ marginVertical: 16 }} />
-    ) : (
-      <View style={{ marginBottom: 15 }} />
+        if (fetched.length > 0) {
+          const lastItem = fetched[fetched.length - 1] as any;
+          setCursorId(lastItem.id ?? null);
+        }
+      } catch (err) {
+        showBottomToast('error', '리스트 불러오기 오류'); // TODO: locales
+      } finally {
+        setLoading(false);
+      }
+    }, [apiCall, loading, hasMore, refreshing, cursorId, defaultParams, pageSize]);
+
+    const onRefresh = useCallback(async () => {
+      setRefreshing(true);
+      setHasMore(true);
+
+      try {
+        const fetched = await apiCall({
+          ...defaultParams,
+          id: null,
+          size: pageSize,
+        });
+
+        setData(fetched); // 덮어쓰기
+
+        if (fetched.length > 0) {
+          const lastItem = fetched[fetched.length - 1] as any;
+          setCursorId(lastItem.id ?? null);
+        } else {
+          setCursorId(null);
+        }
+
+        if (fetched.length < pageSize) {
+          setHasMore(false);
+        }
+      } catch (error) {
+        showBottomToast('error', '새로고침 오류'); // TODO: locales
+      } finally {
+        setRefreshing(false);
+      }
+    }, [apiCall, defaultParams, pageSize]);
+
+    /** [중요] defaultParams가 바뀌었을 때만 초기화 (페이지 진입 시 자동실행)
+     * 부모 컴포넌트에서 defaultParams를 useMemo로 감싸야
+     * 리스트가 깜빡이지 않고 로드됨
+     */
+    useEffect(() => {
+      if (data.length === 0) {
+        fetchData();
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [defaultParams]);
+
+    const renderFooter = () =>
+      loading ? (
+        <ActivityIndicator color={theme.color['gray/gray300']} style={{ marginVertical: 16 }} />
+      ) : (
+        <View style={{ marginBottom: 15 }} />
+      );
+
+    return (
+      <FlatList
+        data={data}
+        extraData={data}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        onEndReached={fetchData}
+        onEndReachedThreshold={onEndReachedThreshold}
+        ListFooterComponent={renderFooter}
+        ListEmptyComponent={!loading ? ListEmptyComponent : null}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={theme.color['gray/gray300']}
+          />
+        }
+        ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
+        showsVerticalScrollIndicator={false}
+        showsHorizontalScrollIndicator={false}
+        {...flatListProps}
+      />
     );
+  },
+);
 
-  return (
-    <FlatList
-      data={data}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      onEndReached={fetchData}
-      onEndReachedThreshold={onEndReachedThreshold}
-      ListFooterComponent={renderFooter}
-      ListEmptyComponent={!loading ? ListEmptyComponent : null}
-      ItemSeparatorComponent={() => <View style={{ height: 12 }} />}
-      showsVerticalScrollIndicator={false}
-      showsHorizontalScrollIndicator={false}
-      {...flatListProps}
-    />
-  );
-};
-
-export default InfiniteScrollList;
+export default InfiniteScrollList as <T>(
+  props: InfiniteScrollListProps<T> & { ref?: React.Ref<InfiniteScrollListRef<T>> },
+) => React.ReactElement;

--- a/src/hooks/useOptimisticCommunityUpdate/index.ts
+++ b/src/hooks/useOptimisticCommunityUpdate/index.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from 'react';
+import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { InfiniteScrollListRef } from '../../components/common/InfiniteScrollList';
+import { CommunityPuzzle, RootStackParamList } from '../../types';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+const useOptimisticCommunityUpdate = () => {
+  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+  const route = useRoute<RouteProp<RootStackParamList, 'CommunityPuzzles'>>();
+
+  const listRef = useRef<InfiniteScrollListRef<CommunityPuzzle>>(null);
+
+  useEffect(() => {
+    const updatedItem = route.params?.updatedItem;
+
+    if (updatedItem) {
+      const { id, likeCount, views, isSolved } = route.params.updatedItem;
+
+      listRef.current?.updateItem(id, (prevItem) => ({
+        ...prevItem,
+        likeCount: likeCount !== undefined ? likeCount : prevItem.likeCount,
+        views: views !== undefined ? views : prevItem.views,
+        isSolved: isSolved !== undefined ? isSolved : prevItem.isSolved,
+      }));
+
+      navigation.setParams({ updatedItem: null });
+    }
+  }, [route.params?.updatedItem, navigation]);
+
+  return listRef;
+};
+
+export default useOptimisticCommunityUpdate;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -89,7 +89,8 @@
     "communityPuzzleFailure": {
       "title": "퍼즐 풀기 실패",
       "message": "오목을 완성하지 못했습니다.",
-      "confirm": "나가기"
+      "confirm": "나가기",
+      "cancel": "재도전"
     },
     "rankingPuzzleFailure": {
       "message": "오목을 완성하지 못했습니다."

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -89,7 +89,8 @@
     "communityPuzzleFailure": {
       "title": "퍼즐 풀기 실패",
       "message": "오목을 완성하지 못했습니다.",
-      "confirm": "나가기"
+      "confirm": "나가기",
+      "cancel": "재도전"
     },
     "rankingPuzzleFailure": {
       "message": "오목을 완성하지 못했습니다."

--- a/src/screens/CommunityPuzzleSolve/index.tsx
+++ b/src/screens/CommunityPuzzleSolve/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   BoardReactionWrapper,
   BoardStatsWrapper,
@@ -22,7 +22,12 @@ import {
   updateLike,
 } from '../../apis/community';
 import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
-import { CommunityPuzzle, ReactionType, RootStackParamList } from '../../types';
+import {
+  CommunityPuzzle,
+  CommunityPuzzlePatch,
+  ReactionType,
+  RootStackParamList,
+} from '../../types';
 import { ActivityIndicator } from 'react-native';
 import theme from '../../styles/theme';
 import useModal from '../../hooks/useModal';
@@ -40,9 +45,20 @@ const CommunityPuzzleSolve = () => {
     category: modalCategory,
   } = useModal();
   const { updateUser } = useUserStore();
+  const { fromScreen = 'CommunityPuzzles' } = route.params;
   const [puzzleDetail, setPuzzleDetail] = useState<CommunityPuzzle | null>(route.params.puzzle);
   const [isLoading, setIsLoading] = useState(true);
   const [boardKey, setBoardKey] = useState(0);
+  const puzzleDetailRef = useRef(puzzleDetail);
+
+  const markSolved = () => {
+    setPuzzleDetail((prev) => {
+      if (!prev) {
+        return prev;
+      }
+      return { ...prev, isSolved: true };
+    });
+  };
 
   const handleResult = async (result: boolean | null) => {
     if (result === null || !puzzleDetail) {
@@ -50,6 +66,8 @@ const CommunityPuzzleSolve = () => {
     }
     if (result) {
       await solveCommunityPuzzle(puzzleDetail.id);
+
+      markSolved();
 
       activateModal('COMMUNITY_PUZZLE_SUCCESS', {
         primaryAction: () => {
@@ -124,6 +142,9 @@ const CommunityPuzzleSolve = () => {
       setIsLoading(true);
       try {
         const data = await openCommunityAnswer(puzzleDetail.id);
+
+        markSolved();
+
         const problemSequence = puzzleDetail.boardStatus;
         const mainSequence = problemSequence + data.answer;
 
@@ -146,6 +167,29 @@ const CommunityPuzzleSolve = () => {
       primaryAction: openAnswer,
     });
   };
+
+  useEffect(() => {
+    puzzleDetailRef.current = puzzleDetail;
+  }, [puzzleDetail]);
+
+  useEffect(() => {
+    return () => {
+      const lastDetail = puzzleDetailRef.current;
+
+      if (!lastDetail) {
+        return;
+      }
+
+      navigation.navigate(fromScreen, {
+        updatedItem: {
+          id: lastDetail.id,
+          likeCount: lastDetail.likeCount,
+          views: lastDetail.views,
+          isSolved: lastDetail.isSolved,
+        } satisfies CommunityPuzzlePatch,
+      });
+    };
+  }, []);
 
   useEffect(() => {
     const getDetail = async () => {

--- a/src/screens/CommunityPuzzleSolve/index.tsx
+++ b/src/screens/CommunityPuzzleSolve/index.tsx
@@ -61,6 +61,9 @@ const CommunityPuzzleSolve = () => {
         primaryAction: async () => {
           navigation.goBack();
         },
+        secondaryAction: () => {
+          handleRetry();
+        },
       });
     }
   };

--- a/src/screens/CommunityPuzzles/index.tsx
+++ b/src/screens/CommunityPuzzles/index.tsx
@@ -1,10 +1,13 @@
-import React, { useCallback, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { ButtonWrapper, Container, EmptyContainer } from './index.styles';
-import InfiniteScrollList from '../../components/common/InfiniteScrollList';
-import { CommunityPuzzle } from '../../types';
+import InfiniteScrollList, {
+  ApiCallParams,
+  InfiniteScrollListRef,
+} from '../../components/common/InfiniteScrollList';
+import { CommunityPuzzle, RootStackParamList } from '../../types';
 import { getCommunityPuzzles } from '../../apis/community';
 import CommunityCard from '../../components/features/CommunityCard';
-import { ParamListBase, useFocusEffect, useNavigation } from '@react-navigation/native';
+import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { CustomText, Icon } from '../../components/common';
 import { useTranslation } from 'react-i18next';
@@ -12,25 +15,39 @@ import CircleButton from '../../components/features/CircleButton';
 
 const CommunityPuzzles = () => {
   const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+  const route = useRoute<RouteProp<RootStackParamList, 'CommunityPuzzles'>>();
   const { t } = useTranslation();
-  const [refreshKey, setRefreshKey] = useState(0);
+  const listRef = useRef<InfiniteScrollListRef<CommunityPuzzle>>(null);
 
-  useFocusEffect(
-    useCallback(() => {
-      // list refresh
-      setRefreshKey((prev) => prev + 1);
-    }, []),
-  );
+  // TODO: 검색 기능 추가 시 변수화 필요
+  const apiParams = useMemo<Partial<ApiCallParams>>(() => ({}), []);
 
   const navigateToCommunityDetail = (puzzle: CommunityPuzzle) => {
-    navigation.navigate('CommunityPuzzleSolve', { puzzle });
+    navigation.navigate('CommunityPuzzleSolve', { puzzle, fromScreen: 'CommunityPuzzles' });
   };
+
+  // Optimistic update
+  useEffect(() => {
+    if (route.params?.updatedItem) {
+      const { id, likeCount, views, isSolved } = route.params.updatedItem;
+
+      listRef.current?.updateItem(id, (prevItem) => ({
+        ...prevItem,
+        likeCount: likeCount,
+        views: views,
+        isSolved: isSolved,
+      }));
+
+      navigation.setParams({ updatedItem: null });
+    }
+  }, [route.params?.updatedItem, navigation]);
 
   return (
     <Container>
       <InfiniteScrollList<CommunityPuzzle>
-        key={refreshKey}
+        ref={listRef}
         apiCall={getCommunityPuzzles}
+        defaultParams={apiParams}
         renderItem={({ item }) => (
           <CommunityCard
             title={item.authorName}

--- a/src/screens/CommunityPuzzles/index.tsx
+++ b/src/screens/CommunityPuzzles/index.tsx
@@ -1,23 +1,20 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { ButtonWrapper, Container, EmptyContainer } from './index.styles';
-import InfiniteScrollList, {
-  ApiCallParams,
-  InfiniteScrollListRef,
-} from '../../components/common/InfiniteScrollList';
-import { CommunityPuzzle, RootStackParamList } from '../../types';
+import InfiniteScrollList, { ApiCallParams } from '../../components/common/InfiniteScrollList';
+import { CommunityPuzzle } from '../../types';
 import { getCommunityPuzzles } from '../../apis/community';
 import CommunityCard from '../../components/features/CommunityCard';
-import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { ParamListBase, useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { CustomText, Icon } from '../../components/common';
 import { useTranslation } from 'react-i18next';
 import CircleButton from '../../components/features/CircleButton';
+import useOptimisticCommunityUpdate from '../../hooks/useOptimisticCommunityUpdate';
 
 const CommunityPuzzles = () => {
   const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
-  const route = useRoute<RouteProp<RootStackParamList, 'CommunityPuzzles'>>();
   const { t } = useTranslation();
-  const listRef = useRef<InfiniteScrollListRef<CommunityPuzzle>>(null);
+  const listRef = useOptimisticCommunityUpdate();
 
   // TODO: 검색 기능 추가 시 변수화 필요
   const apiParams = useMemo<Partial<ApiCallParams>>(() => ({}), []);
@@ -25,22 +22,6 @@ const CommunityPuzzles = () => {
   const navigateToCommunityDetail = (puzzle: CommunityPuzzle) => {
     navigation.navigate('CommunityPuzzleSolve', { puzzle, fromScreen: 'CommunityPuzzles' });
   };
-
-  // Optimistic update
-  useEffect(() => {
-    if (route.params?.updatedItem) {
-      const { id, likeCount, views, isSolved } = route.params.updatedItem;
-
-      listRef.current?.updateItem(id, (prevItem) => ({
-        ...prevItem,
-        likeCount: likeCount,
-        views: views,
-        isSolved: isSolved,
-      }));
-
-      navigation.setParams({ updatedItem: null });
-    }
-  }, [route.params?.updatedItem, navigation]);
 
   return (
     <Container>

--- a/src/screens/LikedPuzzles/index.tsx
+++ b/src/screens/LikedPuzzles/index.tsx
@@ -1,19 +1,16 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { Container } from './index.styles';
-import InfiniteScrollList, {
-  ApiCallParams,
-  InfiniteScrollListRef,
-} from '../../components/common/InfiniteScrollList';
-import { CommunityPuzzle, RootStackParamList } from '../../types';
+import InfiniteScrollList, { ApiCallParams } from '../../components/common/InfiniteScrollList';
+import { CommunityPuzzle } from '../../types';
 import { getLikedPuzzles } from '../../apis/user';
 import CommunityCard from '../../components/features/CommunityCard';
-import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { ParamListBase, useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import useOptimisticCommunityUpdate from '../../hooks/useOptimisticCommunityUpdate';
 
 const LikedPuzzles = () => {
   const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
-  const route = useRoute<RouteProp<RootStackParamList, 'CommunityPuzzles'>>();
-  const listRef = useRef<InfiniteScrollListRef<CommunityPuzzle>>(null);
+  const listRef = useOptimisticCommunityUpdate();
 
   const apiParams = useMemo<Partial<ApiCallParams>>(() => ({}), []);
 
@@ -23,22 +20,6 @@ const LikedPuzzles = () => {
       fromScreen: 'LikedPuzzles',
     });
   };
-
-  // Optimistic update
-  useEffect(() => {
-    if (route.params?.updatedItem) {
-      const { id, likeCount, views, isSolved } = route.params.updatedItem;
-
-      listRef.current?.updateItem(id, (prevItem) => ({
-        ...prevItem,
-        likeCount: likeCount,
-        views: views,
-        isSolved: isSolved,
-      }));
-
-      navigation.setParams({ updatedItem: null });
-    }
-  }, [route.params?.updatedItem, navigation]);
 
   return (
     <Container>

--- a/src/screens/LikedPuzzles/index.tsx
+++ b/src/screens/LikedPuzzles/index.tsx
@@ -1,28 +1,51 @@
-import React, { useCallback, useState } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { Container } from './index.styles';
-import InfiniteScrollList from '../../components/common/InfiniteScrollList';
-import { CommunityPuzzle } from '../../types';
+import InfiniteScrollList, {
+  ApiCallParams,
+  InfiniteScrollListRef,
+} from '../../components/common/InfiniteScrollList';
+import { CommunityPuzzle, RootStackParamList } from '../../types';
 import { getLikedPuzzles } from '../../apis/user';
 import CommunityCard from '../../components/features/CommunityCard';
-import { ParamListBase, useFocusEffect, useNavigation } from '@react-navigation/native';
+import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 const LikedPuzzles = () => {
   const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
-  const [refreshKey, setRefreshKey] = useState(0);
+  const route = useRoute<RouteProp<RootStackParamList, 'CommunityPuzzles'>>();
+  const listRef = useRef<InfiniteScrollListRef<CommunityPuzzle>>(null);
 
-  useFocusEffect(
-    useCallback(() => {
-      // list refresh
-      setRefreshKey((prev) => prev + 1);
-    }, []),
-  );
+  const apiParams = useMemo<Partial<ApiCallParams>>(() => ({}), []);
+
+  const navigateToCommunityDetail = (puzzle: CommunityPuzzle) => {
+    navigation.navigate('CommunityPuzzleSolve', {
+      puzzle: puzzle,
+      fromScreen: 'LikedPuzzles',
+    });
+  };
+
+  // Optimistic update
+  useEffect(() => {
+    if (route.params?.updatedItem) {
+      const { id, likeCount, views, isSolved } = route.params.updatedItem;
+
+      listRef.current?.updateItem(id, (prevItem) => ({
+        ...prevItem,
+        likeCount: likeCount,
+        views: views,
+        isSolved: isSolved,
+      }));
+
+      navigation.setParams({ updatedItem: null });
+    }
+  }, [route.params?.updatedItem, navigation]);
 
   return (
     <Container>
       <InfiniteScrollList<CommunityPuzzle>
-        key={refreshKey}
+        ref={listRef}
         apiCall={({ id, size }) => getLikedPuzzles(id, size)}
+        defaultParams={apiParams}
         renderItem={({ item }) => (
           <CommunityCard
             title={item.authorName}
@@ -36,7 +59,7 @@ const LikedPuzzles = () => {
             solvedCount={item.solvedCount}
             likeCount={item.likeCount}
             isSolved={item.isSolved}
-            onPress={() => navigation.navigate('CommunityPuzzleSolve', { puzzle: item })}
+            onPress={() => navigateToCommunityDetail(item)}
           />
         )}
         keyExtractor={(item) => item && item.id.toString()}

--- a/src/screens/MyPuzzles/index.tsx
+++ b/src/screens/MyPuzzles/index.tsx
@@ -1,17 +1,23 @@
-import React, { useCallback, useState } from 'react';
-import InfiniteScrollList from '../../components/common/InfiniteScrollList';
+import React, { useEffect, useMemo, useRef } from 'react';
+import InfiniteScrollList, {
+  ApiCallParams,
+  InfiniteScrollListRef,
+} from '../../components/common/InfiniteScrollList';
 import { deleteMyPuzzle, getUserPuzzles } from '../../apis/user';
 import CommunityCard from '../../components/features/CommunityCard';
-import { CommunityPuzzle } from '../../types';
+import { CommunityPuzzle, RootStackParamList } from '../../types';
 import { Container } from './index.styles';
 import { CustomModal } from '../../components/common';
 import useModal from '../../hooks/useModal';
-import { ParamListBase, useFocusEffect, useNavigation } from '@react-navigation/native';
+import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import { showBottomToast } from '../../components/common/Toast/toastMessage';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 
 const MyPuzzles = () => {
   const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+  const route = useRoute<RouteProp<RootStackParamList, 'CommunityPuzzles'>>();
+  const listRef = useRef<InfiniteScrollListRef<CommunityPuzzle>>(null);
+  const apiParams = useMemo<Partial<ApiCallParams>>(() => ({}), []);
   const {
     isModalVisible,
     activateModal,
@@ -19,14 +25,21 @@ const MyPuzzles = () => {
     closeSecondarily,
     category: modalCategory,
   } = useModal();
-  const [refreshKey, setRefreshKey] = useState(0);
+
+  const navigateToCommunityDetail = (puzzle: CommunityPuzzle) => {
+    navigation.navigate('CommunityPuzzleSolve', {
+      puzzle: puzzle,
+      fromScreen: 'Mypuzzles',
+    });
+  };
 
   const handleDelete = async (id: number) => {
     activateModal('DELETE_PUZZLE_CONFIRM', {
       primaryAction: async () => {
         try {
           await deleteMyPuzzle(id);
-          setRefreshKey((prev) => prev + 1);
+          listRef.current?.removeItem(id);
+
           showBottomToast('success', '퍼즐이 삭제되었습니다.');
         } catch (error) {
           showBottomToast('error', error as string);
@@ -35,18 +48,28 @@ const MyPuzzles = () => {
     });
   };
 
-  useFocusEffect(
-    useCallback(() => {
-      // list refresh
-      setRefreshKey((prev) => prev + 1);
-    }, []),
-  );
+  // Optimistic update
+  useEffect(() => {
+    if (route.params?.updatedItem) {
+      const { id, likeCount, views, isSolved } = route.params.updatedItem;
+
+      listRef.current?.updateItem(id, (prevItem) => ({
+        ...prevItem,
+        likeCount: likeCount,
+        views: views,
+        isSolved: isSolved,
+      }));
+
+      navigation.setParams({ updatedItem: null });
+    }
+  }, [route.params?.updatedItem, navigation]);
 
   return (
     <Container>
       <InfiniteScrollList<CommunityPuzzle>
-        key={refreshKey}
+        ref={listRef}
         apiCall={getUserPuzzles}
+        defaultParams={apiParams}
         renderItem={({ item }) => (
           <CommunityCard
             title={item.authorName}
@@ -60,7 +83,7 @@ const MyPuzzles = () => {
             solvedCount={item.solvedCount}
             likeCount={item.likeCount}
             isSolved={item.isSolved}
-            onPress={() => navigation.navigate('CommunityPuzzleSolve', { puzzle: item })}
+            onPress={() => navigateToCommunityDetail(item)}
             onDelete={() => handleDelete(item.id)}
           />
         )}

--- a/src/screens/MyPuzzles/index.tsx
+++ b/src/screens/MyPuzzles/index.tsx
@@ -1,22 +1,19 @@
-import React, { useEffect, useMemo, useRef } from 'react';
-import InfiniteScrollList, {
-  ApiCallParams,
-  InfiniteScrollListRef,
-} from '../../components/common/InfiniteScrollList';
+import React, { useMemo } from 'react';
+import InfiniteScrollList, { ApiCallParams } from '../../components/common/InfiniteScrollList';
 import { deleteMyPuzzle, getUserPuzzles } from '../../apis/user';
 import CommunityCard from '../../components/features/CommunityCard';
-import { CommunityPuzzle, RootStackParamList } from '../../types';
+import { CommunityPuzzle } from '../../types';
 import { Container } from './index.styles';
 import { CustomModal } from '../../components/common';
 import useModal from '../../hooks/useModal';
-import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
+import { ParamListBase, useNavigation } from '@react-navigation/native';
 import { showBottomToast } from '../../components/common/Toast/toastMessage';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import useOptimisticCommunityUpdate from '../../hooks/useOptimisticCommunityUpdate';
 
 const MyPuzzles = () => {
   const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
-  const route = useRoute<RouteProp<RootStackParamList, 'CommunityPuzzles'>>();
-  const listRef = useRef<InfiniteScrollListRef<CommunityPuzzle>>(null);
+  const listRef = useOptimisticCommunityUpdate();
   const apiParams = useMemo<Partial<ApiCallParams>>(() => ({}), []);
   const {
     isModalVisible,
@@ -29,7 +26,7 @@ const MyPuzzles = () => {
   const navigateToCommunityDetail = (puzzle: CommunityPuzzle) => {
     navigation.navigate('CommunityPuzzleSolve', {
       puzzle: puzzle,
-      fromScreen: 'Mypuzzles',
+      fromScreen: 'MyPuzzles',
     });
   };
 
@@ -47,22 +44,6 @@ const MyPuzzles = () => {
       },
     });
   };
-
-  // Optimistic update
-  useEffect(() => {
-    if (route.params?.updatedItem) {
-      const { id, likeCount, views, isSolved } = route.params.updatedItem;
-
-      listRef.current?.updateItem(id, (prevItem) => ({
-        ...prevItem,
-        likeCount: likeCount,
-        views: views,
-        isSolved: isSolved,
-      }));
-
-      navigation.setParams({ updatedItem: null });
-    }
-  }, [route.params?.updatedItem, navigation]);
 
   return (
     <Container>

--- a/src/types/ParamList/index.ts
+++ b/src/types/ParamList/index.ts
@@ -3,6 +3,10 @@ import { CommunityPuzzle, TrainingPack, TrainingPuzzle } from '../Puzzle';
 export type RootStackParamList = {
   CommunityPuzzleSolve: {
     puzzle: CommunityPuzzle;
+    fromScreen?: 'CommunityPuzzles' | 'MyPuzzles' | 'LikedPuzzles';
+  };
+  CommunityPuzzles: {
+    updatedItem?: CommunityPuzzle;
   };
   TrainingPuzzleSolve: {
     puzzles: TrainingPuzzle[];

--- a/src/types/Puzzle/index.ts
+++ b/src/types/Puzzle/index.ts
@@ -16,6 +16,9 @@ export interface CommunityPuzzle {
   myDislike?: boolean;
 }
 
+export type CommunityPuzzlePatch = Pick<CommunityPuzzle, 'id'> &
+  Partial<Omit<CommunityPuzzle, 'id'>>;
+
 export interface TrainingPack {
   id: number;
   title: string;


### PR DESCRIPTION
- 커뮤니티 퍼즐 실패 시 모달에 재도전 버튼 추가
- 커뮤니티 퍼즐 리스트 리렌더링 방식 (접근할 때마다 API 새로 불러오는 비효율) → 낙관적 업데이트 방식으로 변경
    - 기존 useFocusEffect로 접근 시마다 새로 렌더링 했던 방식에서,
    - useMemo로 스크롤 위치와 데이터 모두 기억해두고 사용자의 변경 상태(조회/좋아요/풀이여부) 전달하는 방식으로 해결