### PR TITLE
feat: add killer move ordering & optimization in renzzle engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ yarn-error.log
 # Ruby / CocoaPods
 **/Pods/
 /vendor/bundle/
+.ruby-version
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*
@@ -78,3 +79,6 @@ yarn-error.log
 .env
 env.d.ts
 .env.local
+
+# Claude Code
+.claude/

--- a/android/app/src/main/java/com/renzzle_fe/cpp/engine/engine.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/engine/engine.h
@@ -156,7 +156,8 @@ FindNextMoveAnalysis analyzeNextMove(string boardStr, EngineCancelToken* cancelT
     }
 
     // safety net: no completed iteration → pick any reasonable candidate
-    MoveList moves = evaluator.getCandidates();
+    CandidateList moves;
+    evaluator.getCandidates(moves);
     if (!moves.empty()) {
         Pos fallback = moves[0];
         analysis.move = convertMoveToInt(fallback);

--- a/android/app/src/main/java/com/renzzle_fe/cpp/evaluate/evaluator.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/evaluate/evaluator.h
@@ -14,9 +14,6 @@ PRIVATE
     Piece self = BLACK;
     Piece oppo = WHITE;
 
-    const MoveBucket* patternMap[2][COMPOSITE_PATTERN_SIZE] = {};
-
-    void classify();
     int evaluatePatternBalance();
     const MoveBucket& bucket(Piece piece, CompositePattern pattern) const;
     bool hasPattern(Piece piece, CompositePattern pattern) const;
@@ -27,12 +24,18 @@ PUBLIC
     Evaluator(Board& board);
     Value quickWinCheck(Pos* bestMove = nullptr);
     MoveList getCandidates();
+    void getCandidates(CandidateList& result);
     Pos getSureMove();
     MoveList getFours();
+    void getFours(CandidateList& result);
     MoveList getThreats();
+    void getThreats(CandidateList& result);
     MoveList getThreatDefend();
+    void getThreatDefend(CandidateList& result);
     MoveList getFourThreeMakers();
+    void getFourThreeMakers(CandidateList& result);
     MoveList getFourThreeDefend();
+    void getFourThreeDefend(CandidateList& result);
     Pos getOppoWinningDefend();
     bool isOppoMateExist();
     bool isOppoFourThreeExist();
@@ -94,12 +97,13 @@ inline Value evaluateTacticalSummary(Board& board) {
     return Value(val);
 }
 
-Evaluator::Evaluator(Board& board) : board(board) {
-    classify();
-}
+Evaluator::Evaluator(Board& board)
+    : board(board),
+      self(board.isBlackTurn() ? BLACK : WHITE),
+      oppo(board.isBlackTurn() ? WHITE : BLACK) {}
 
 const MoveBucket& Evaluator::bucket(Piece piece, CompositePattern pattern) const {
-    return *patternMap[piece][pattern];
+    return board.getPatternBucket(piece, pattern);
 }
 
 bool Evaluator::hasPattern(Piece piece, CompositePattern pattern) const {
@@ -116,18 +120,6 @@ bool Evaluator::hasFourLevelPressure(Piece piece) const {
 
 int Evaluator::patternCount(Piece piece, CompositePattern pattern) const {
     return bucket(piece, pattern).size();
-}
-
-void Evaluator::classify() {
-    self = board.isBlackTurn() ? BLACK : WHITE;
-    oppo = !board.isBlackTurn() ? BLACK : WHITE;
-
-    for (int color = 0; color < 2; ++color) {
-        for (int pattern = 0; pattern < COMPOSITE_PATTERN_SIZE; ++pattern) {
-            patternMap[color][pattern] =
-                &board.getPatternBucket(static_cast<Piece>(color), static_cast<CompositePattern>(pattern));
-        }
-    }
 }
 
 int Evaluator::evaluatePatternBalance() {
@@ -237,16 +229,23 @@ Value Evaluator::quickWinCheck(Pos* bestMove) {
 }
 
 MoveList Evaluator::getCandidates() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getCandidates(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getCandidates(CandidateList& result) {
+    result.clear();
 
     Pos sureMove = getSureMove();
     if (!sureMove.isDefault()) {
         result.push_back(sureMove);
-        return result.toMoveList();
+        return;
     }
 
     if (isOppoMateExist()) {
-        return getThreatDefend();
+        getThreatDefend(result);
+        return;
     }
 
     result.reserve(
@@ -278,8 +277,6 @@ MoveList Evaluator::getCandidates() {
     sort(result.begin(), result.end(), [&](const Pos& a, const Pos& b) {
         return board.getCell(a).getScore(self) > board.getCell(b).getScore(self);
     });
-
-    return result.toMoveList();
 }
 
 Pos Evaluator::getSureMove() {
@@ -287,7 +284,7 @@ Pos Evaluator::getSureMove() {
         return board.getFirstPatternPos(self, WINNING);
     }
     if (board.hasCompositePattern(oppo, WINNING)) {
-        MoveList result;
+        CandidateList result;
         result.reserve(board.getCompositePatternCount(oppo, WINNING));
         bucket(oppo, WINNING).forEach([&](const Pos& p) {
             if (!isMoveForbidden(p)) result.push_back(p);
@@ -314,14 +311,20 @@ Pos Evaluator::getSureMove() {
 }
 
 MoveList Evaluator::getFours() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getFours(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getFours(CandidateList& result) {
+    result.clear();
     if (hasPattern(self, WINNING)) {
-        result.push_back(bucket(self, WINNING).front()); 
-        return result.toMoveList();
+        result.push_back(bucket(self, WINNING).front());
+        return;
     }
     if (hasPattern(self, MATE)) {
         result.push_back(bucket(self, MATE).front());
-        return result.toMoveList();
+        return;
     }
     result.reserve(
         patternCount(self, B4_F3) +
@@ -334,19 +337,23 @@ MoveList Evaluator::getFours() {
     stable_sort(result.begin(), result.end(), [&](const Pos& a, const Pos& b) {
         return board.getCell(a).getScore(oppo) > board.getCell(b).getScore(oppo);
     });
-
-    return result.toMoveList();
 }
 
 MoveList Evaluator::getThreats() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getThreats(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getThreats(CandidateList& result) {
+    result.clear();
     if (hasPattern(self, WINNING)) {
         result.push_back(bucket(self, WINNING).front());
-        return result.toMoveList();
+        return;
     }
     if (hasPattern(self, MATE)) {
         result.push_back(bucket(self, MATE).front());
-        return result.toMoveList();
+        return;
     }
     result.reserve(
         patternCount(self, B4_F3) +
@@ -363,11 +370,16 @@ MoveList Evaluator::getThreats() {
     bucket(self, B4_ANY).forEach([&](const Pos& p) { result.push_back(p); });
 
     // sort omitted — Search::sortChildNodes handles ordering uniformly (cellScore + TT/history)
-    return result.toMoveList();
 }
 
 MoveList Evaluator::getThreatDefend() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getThreatDefend(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getThreatDefend(CandidateList& result) {
+    result.clear();
     array<uint8_t, 256> seen = {};
     auto appendUniqueLegal = [&](const Pos& p) {
         if (isMoveForbidden(p)) return;
@@ -377,7 +389,7 @@ MoveList Evaluator::getThreatDefend() {
         result.push_back(p);
     };
 
-    if (!isOppoMateExist()) return result.toMoveList();
+    if (!isOppoMateExist()) return;
 
     if (hasPattern(oppo, WINNING)) {
         result.reserve(patternCount(oppo, WINNING));
@@ -385,7 +397,7 @@ MoveList Evaluator::getThreatDefend() {
             appendUniqueLegal(p);
         });
         if (!result.empty()) {
-            return result.toMoveList();
+            return;
         }
     }
 
@@ -443,7 +455,7 @@ MoveList Evaluator::getThreatDefend() {
                     Pos cp(r, c);
                     if (!isMoveForbidden(cp)) {
                         result.push_back(cp);
-                        return result.toMoveList();
+                        return;
                     }
                 }
             }
@@ -451,11 +463,16 @@ MoveList Evaluator::getThreatDefend() {
     }
 
     // sort omitted — Search::sortChildNodes handles ordering uniformly (cellScore + TT/history)
-    return result.toMoveList();
 }
 
 MoveList Evaluator::getFourThreeMakers() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getFourThreeMakers(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getFourThreeMakers(CandidateList& result) {
+    result.clear();
     array<uint8_t, 256> seen = {};
 
     auto appendUniqueLegal = [&](const Pos& p) {
@@ -531,13 +548,18 @@ MoveList Evaluator::getFourThreeMakers() {
     });
 
     // sort omitted — Search::sortChildNodes handles ordering uniformly (cellScore + TT/history)
-    return result.toMoveList();
 }
 
 MoveList Evaluator::getFourThreeDefend() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getFourThreeDefend(result);
+    return result.toMoveList();
+}
 
-    if (!isOppoFourThreeExist()) return result.toMoveList();
+void Evaluator::getFourThreeDefend(CandidateList& result) {
+    result.clear();
+
+    if (!isOppoFourThreeExist()) return;
 
     const int b43Count = patternCount(oppo, B4_F3);
 
@@ -669,7 +691,7 @@ MoveList Evaluator::getFourThreeDefend() {
             seen[k] = 1;
             result.push_back(p);
         });
-        return result.toMoveList();
+        return;
     }
 
     // If multiple B4_F3's exist, only the intersection of their defenses can effectively block all forks
@@ -700,7 +722,6 @@ MoveList Evaluator::getFourThreeDefend() {
     }
 
     // sort omitted — Search::sortChildNodes handles ordering uniformly (cellScore + TT/history)
-    return result.toMoveList();
 }
 
 Pos Evaluator::getOppoWinningDefend() {

--- a/android/app/src/main/java/com/renzzle_fe/cpp/game/board.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/game/board.h
@@ -21,11 +21,32 @@ PRIVATE
     static constexpr int BIT_DIAG_SIZE = (BIT_LINE_SIZE * 2) - 1;
     static constexpr uint64_t LINE_KEY_MASK = (1ull << (LINE_LENGTH * 2)) - 1ull;
     static constexpr int CENTER_SHIFT = (LINE_LENGTH / 2) * 2;
+    static constexpr int PATTERN_CACHE_COLOR_SHIFT = LINE_LENGTH * 2;
+    static constexpr size_t PATTERN_CACHE_SIZE = 1ull << (PATTERN_CACHE_COLOR_SHIFT + 1);
+
+    struct PatternUndo {
+        uint8_t cellCode = 0;
+        Direction direction = HORIZONTAL;
+        Pattern blackPattern = NONE;
+        Pattern whitePattern = NONE;
+    };
+    static_assert(sizeof(PatternUndo) == 4, "PatternUndo must stay compact.");
+
+    struct BoardUndo {
+        Result previousResult = ONGOING;
+        std::array<Pattern, DIRECTION_SIZE> targetBlackPatterns = {};
+        std::array<Pattern, DIRECTION_SIZE> targetWhitePatterns = {};
+        std::array<PatternUndo, LINE_LENGTH * DIRECTION_SIZE> changedPatterns = {};
+        uint8_t changedPatternCount = 0;
+    };
+
+    using PatternCache = std::array<uint8_t, PATTERN_CACHE_SIZE>;
 
     CellArray cells;
     MoveList path;
+    std::vector<BoardUndo> undoHistory;
     Result result;
-    size_t currentHash;
+    uint64_t currentHash;
     array<uint64_t, BIT_LINE_SIZE> horizontalKeys;
     array<uint64_t, BIT_LINE_SIZE> verticalKeys;
     array<uint64_t, BIT_DIAG_SIZE> upwardKeys;
@@ -33,14 +54,17 @@ PRIVATE
     MoveBucket patternBuckets[2][COMPOSITE_PATTERN_SIZE];
 
     void clearPattern(Cell& cell);
-    void setPatterns(const Pos& p);
+    void setPatterns(const Pos& p, BoardUndo* undoState = nullptr);
     void setResult(const Pos& p);
     void addPatternBucketState(const Pos& p, const Cell& cell);
     void removePatternBucketState(const Pos& p, const Cell& cell);
     Line getLine(int x, int y, Direction dir);
     Pattern getPattern(const Line& line, Color color);
     Pattern getPattern(uint32_t lineKey, Color color);
+    static Pattern calculatePattern(uint32_t lineKey, Color color, PatternCache& cache);
+    static const PatternCache& getPatternCache();
     void setBitKeys(int x, int y, Piece piece);
+    uint64_t getLineBits(int x, int y, Direction dir) const;
     uint32_t getLineKey(int x, int y, Direction dir) const;
     static int toBitCoord(int coord);
     static uint64_t makeFilledBitLine(Piece piece);
@@ -67,8 +91,8 @@ PUBLIC
     Pos getFirstPatternPos(Piece piece, CompositePattern pattern) const;
     const MoveBucket& getPatternBucket(Piece piece, CompositePattern pattern) const;
     MoveList& getPath();
-    size_t getCurrentHash() const;
-    size_t getChildHash(const Pos& p);
+    uint64_t getCurrentHash() const;
+    uint64_t getChildHash(const Pos& p);
     
 };
 
@@ -76,6 +100,7 @@ Board::Board() {
     currentHash = 0;
     result = ONGOING;
     path.reserve(BOARD_SIZE * BOARD_SIZE);
+    undoHistory.reserve(BOARD_SIZE * BOARD_SIZE);
     horizontalKeys.fill(makeFilledBitLine(WALL));
     verticalKeys.fill(makeFilledBitLine(WALL));
     upwardKeys.fill(makeFilledBitLine(WALL));
@@ -130,9 +155,18 @@ bool Board::move(const Pos& p) {
     if (result != ONGOING) return false;
     if (path.size() == BOARD_SIZE * BOARD_SIZE) return false;
 
+    const Result previousResult = result;
     path.push_back(p);
 
     setResult(p);
+
+    undoHistory.emplace_back();
+    BoardUndo& undoState = undoHistory.back();
+    undoState.previousResult = previousResult;
+    for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
+        undoState.targetBlackPatterns[dir] = targetCell.getPattern(BLACK, dir);
+        undoState.targetWhitePatterns[dir] = targetCell.getPattern(WHITE, dir);
+    }
 
     Piece piece = isBlackTurn() ? WHITE : BLACK;
     removePatternBucketState(p, targetCell);
@@ -142,7 +176,7 @@ bool Board::move(const Pos& p) {
 
     clearPattern(targetCell);
     targetCell.clearCompositePattern();
-    setPatterns(p);
+    setPatterns(p, &undoState);
 
     return true;
 }
@@ -154,8 +188,13 @@ void Board::undo() {
     // if passed
     if (p.isDefault()) {
         path.pop_back();
+        if (!undoHistory.empty()) {
+            undoHistory.pop_back();
+        }
         return;
     }
+
+    BoardUndo& undoState = undoHistory.back();
 
     Cell& targetCell = getCell(p);
     Piece piece = targetCell.getPiece();
@@ -165,8 +204,64 @@ void Board::undo() {
     setBitKeys(p.x, p.y, EMPTY);
 
     path.pop_back();
-    setPatterns(p);
-    result = ONGOING;
+
+    for (uint8_t i = 0; i < undoState.changedPatternCount; ++i) {
+        const PatternUndo& patternUndo = undoState.changedPatterns[i];
+        const Pos changedPos(patternUndo.cellCode >> 4, patternUndo.cellCode & 0x0F);
+        Cell& cell = getCell(changedPos);
+        removePatternBucketState(changedPos, cell);
+
+        Pattern blackPattern = patternUndo.blackPattern;
+        Pattern whitePattern = patternUndo.whitePattern;
+        if (blackPattern == NONE || whitePattern == NONE) {
+            const uint32_t lineKey =
+                getLineKey(changedPos.x, changedPos.y, patternUndo.direction);
+            if (blackPattern == NONE) {
+                const uint32_t blackLineKey =
+                    (lineKey & ~(0x3u << CENTER_SHIFT))
+                    | (static_cast<uint32_t>(BLACK) << CENTER_SHIFT);
+                blackPattern = getPattern(blackLineKey, COLOR_BLACK);
+            }
+            if (whitePattern == NONE) {
+                const uint32_t whiteLineKey =
+                    (lineKey & ~(0x3u << CENTER_SHIFT))
+                    | (static_cast<uint32_t>(WHITE) << CENTER_SHIFT);
+                whitePattern = getPattern(whiteLineKey, COLOR_WHITE);
+            }
+        }
+
+        cell.setPattern(BLACK, patternUndo.direction, blackPattern);
+        cell.setPattern(WHITE, patternUndo.direction, whitePattern);
+        cell.updateDerived();
+        addPatternBucketState(changedPos, cell);
+    }
+
+    for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
+        Pattern blackPattern = undoState.targetBlackPatterns[dir];
+        Pattern whitePattern = undoState.targetWhitePatterns[dir];
+        if (blackPattern == NONE || whitePattern == NONE) {
+            const uint32_t lineKey = getLineKey(p.x, p.y, dir);
+            if (blackPattern == NONE) {
+                const uint32_t blackLineKey =
+                    (lineKey & ~(0x3u << CENTER_SHIFT))
+                    | (static_cast<uint32_t>(BLACK) << CENTER_SHIFT);
+                blackPattern = getPattern(blackLineKey, COLOR_BLACK);
+            }
+            if (whitePattern == NONE) {
+                const uint32_t whiteLineKey =
+                    (lineKey & ~(0x3u << CENTER_SHIFT))
+                    | (static_cast<uint32_t>(WHITE) << CENTER_SHIFT);
+                whitePattern = getPattern(whiteLineKey, COLOR_WHITE);
+            }
+        }
+        targetCell.setPattern(BLACK, dir, blackPattern);
+        targetCell.setPattern(WHITE, dir, whitePattern);
+    }
+    targetCell.updateDerived();
+    addPatternBucketState(p, targetCell);
+
+    result = undoState.previousResult;
+    undoHistory.pop_back();
 }
 
 bool Board::pass() {
@@ -175,7 +270,8 @@ bool Board::pass() {
 
     Pos p;
     path.push_back(p);
-    return true;    
+    undoHistory.emplace_back();
+    return true;
 }
 
 Result Board::getResult() {
@@ -277,12 +373,12 @@ const MoveBucket& Board::getPatternBucket(Piece piece, CompositePattern pattern)
     return patternBuckets[piece][pattern];
 }
 
-size_t Board::getCurrentHash() const {
+uint64_t Board::getCurrentHash() const {
     return currentHash;
 }
 
-size_t Board::getChildHash(const Pos& p) {
-    size_t result = currentHash;
+uint64_t Board::getChildHash(const Pos& p) {
+    uint64_t result = currentHash;
     Piece piece = isBlackTurn() ? BLACK : WHITE;
     result ^= getZobristValue(p.x, p.y, piece);
     return result;
@@ -406,22 +502,27 @@ void Board::setBitKeys(int x, int y, Piece piece) {
     downwardKeys[bx + by] = (downwardKeys[bx + by] & ~xMask) | (value << xShift);
 }
 
-uint32_t Board::getLineKey(int x, int y, Direction dir) const {
+uint64_t Board::getLineBits(int x, int y, Direction dir) const {
     const int bx = toBitCoord(x);
     const int by = toBitCoord(y);
 
     switch (dir) {
         case HORIZONTAL:
-            return static_cast<uint32_t>((horizontalKeys[bx] >> ((by - LINE_PADDING) * 2)) & LINE_KEY_MASK);
+            return horizontalKeys[bx] >> ((by - LINE_PADDING) * 2);
         case VERTICAL:
-            return static_cast<uint32_t>((verticalKeys[by] >> ((bx - LINE_PADDING) * 2)) & LINE_KEY_MASK);
+            return verticalKeys[by] >> ((bx - LINE_PADDING) * 2);
         case UPWARD:
-            return static_cast<uint32_t>((upwardKeys[bx - by + (BIT_LINE_SIZE - 1)] >> ((bx - LINE_PADDING) * 2)) & LINE_KEY_MASK);
+            return upwardKeys[bx - by + (BIT_LINE_SIZE - 1)]
+                >> ((bx - LINE_PADDING) * 2);
         case DOWNWARD:
-            return static_cast<uint32_t>((downwardKeys[bx + by] >> ((bx - LINE_PADDING) * 2)) & LINE_KEY_MASK);
+            return downwardKeys[bx + by] >> ((bx - LINE_PADDING) * 2);
         default:
             return 0;
     }
+}
+
+uint32_t Board::getLineKey(int x, int y, Direction dir) const {
+    return static_cast<uint32_t>(getLineBits(x, y, dir) & LINE_KEY_MASK);
 }
 
 void Board::clearPattern(Cell& cell) {
@@ -431,31 +532,58 @@ void Board::clearPattern(Cell& cell) {
     }
 }
 
-void Board::setPatterns(const Pos& p) {
+void Board::setPatterns(const Pos& p, BoardUndo* undoState) {
     const int originX = p.x;
     const int originY = p.y;
 
     std::array<Pos, LINE_LENGTH * DIRECTION_SIZE> touchedCells;
     size_t touchedCount = 0;
-    std::array<std::array<bool, BOARD_SIZE + 2>, BOARD_SIZE + 2> isTouched = {};
+    bool originTouched = false;
 
     for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
         const int dx = getDirectionDx(dir);
         const int dy = getDirectionDy(dir);
-        for (int i = 0; i < LINE_LENGTH; i++) {
-            const int offset = i - (LINE_LENGTH / 2);
+
+        int startOffset = -LINE_PADDING;
+        int endOffset = LINE_PADDING;
+        while (!isBoardCoord(originX + (dx * startOffset), originY + (dy * startOffset))) {
+            ++startOffset;
+        }
+        while (!isBoardCoord(originX + (dx * endOffset), originY + (dy * endOffset))) {
+            --endOffset;
+        }
+
+        const int startX = originX + (dx * startOffset);
+        const int startY = originY + (dy * startOffset);
+        uint64_t slidingBits = getLineBits(startX, startY, dir);
+
+        for (int offset = startOffset; offset <= endOffset; ++offset) {
             const int x = originX + (dx * offset);
             const int y = originY + (dy * offset);
-            if (!isBoardCoord(x, y)) {
-                continue;
-            }
 
             Cell& c = getCell(x, y);
             if (c.getPiece() == EMPTY) {
-                if (!isTouched[x][y]) {
+                const bool isOrigin = offset == 0;
+                const bool firstTouch = !isOrigin || !originTouched;
+                if (firstTouch) {
                     removePatternBucketState(Pos(x, y), c);
+                    touchedCells[touchedCount++] = Pos(x, y);
+                    if (isOrigin) {
+                        originTouched = true;
+                    }
                 }
-                const uint32_t lineKey = getLineKey(x, y, dir);
+
+                if (undoState != nullptr) {
+                    PatternUndo& patternUndo =
+                        undoState->changedPatterns[undoState->changedPatternCount++];
+                    patternUndo.cellCode = static_cast<uint8_t>((x << 4) | y);
+                    patternUndo.direction = dir;
+                    patternUndo.blackPattern = c.getPattern(BLACK, dir);
+                    patternUndo.whitePattern = c.getPattern(WHITE, dir);
+                }
+
+                const uint32_t lineKey =
+                    static_cast<uint32_t>(slidingBits & LINE_KEY_MASK);
                 const uint32_t blackLineKey =
                     (lineKey & ~(0x3u << CENTER_SHIFT)) | (static_cast<uint32_t>(BLACK) << CENTER_SHIFT);
                 const uint32_t whiteLineKey =
@@ -463,12 +591,9 @@ void Board::setPatterns(const Pos& p) {
 
                 c.setPattern(BLACK, dir, getPattern(blackLineKey, COLOR_BLACK));
                 c.setPattern(WHITE, dir, getPattern(whiteLineKey, COLOR_WHITE));
-
-                if (!isTouched[x][y]) {
-                    isTouched[x][y] = true;
-                    touchedCells[touchedCount++] = Pos(x, y);
-                }
             }
+
+            slidingBits >>= 2;
         }
     }
 
@@ -491,7 +616,7 @@ Line Board::getLine(int x, int y, Direction dir) {
         const int ny = y + (dy * offset);
         if (!isBoardCoord(nx, ny)) {
             line[i] = WALL;
-            continue; 
+            continue;
         }
         line[i] = getCell(nx, ny).getPiece();
     }
@@ -508,17 +633,39 @@ Pattern Board::getPattern(const Line& line, Color color) {
 }
 
 Pattern Board::getPattern(uint32_t lineKey, Color color) {
-    constexpr uint32_t PIECE_BITS = 2;
-    constexpr uint32_t COLOR_SHIFT = LINE_LENGTH * PIECE_BITS;
-    constexpr uint32_t CACHE_SIZE = 1u << (COLOR_SHIFT + 1);
+    const uint32_t colorKey = color == COLOR_WHITE
+        ? (1u << PATTERN_CACHE_COLOR_SHIFT)
+        : 0u;
+    return static_cast<Pattern>(getPatternCache()[colorKey | lineKey] - 1);
+}
+
+const Board::PatternCache& Board::getPatternCache() {
+    static const PatternCache patternCache = []() {
+        PatternCache cache = {};
+        const uint32_t lineKeyCount = 1u << PATTERN_CACHE_COLOR_SHIFT;
+        constexpr int mid = LINE_LENGTH / 2;
+
+        for (Color color : {COLOR_BLACK, COLOR_WHITE}) {
+            const Piece self = color == COLOR_BLACK ? BLACK : WHITE;
+            for (uint32_t lineKey = 0; lineKey < lineKeyCount; ++lineKey) {
+                if (getLineKeyPiece(lineKey, mid) == self) {
+                    calculatePattern(lineKey, color, cache);
+                }
+            }
+        }
+        return cache;
+    }();
+    return patternCache;
+}
+
+Pattern Board::calculatePattern(uint32_t lineKey, Color color, PatternCache& cache) {
     constexpr uint8_t CACHE_UNSET = 0;
+    const uint32_t colorKey = color == COLOR_WHITE
+        ? (1u << PATTERN_CACHE_COLOR_SHIFT)
+        : 0u;
+    const uint32_t key = colorKey | lineKey;
 
-    static array<uint8_t, CACHE_SIZE> patternCache = {};
-
-    uint32_t key = (color == COLOR_WHITE) ? (1u << COLOR_SHIFT) : 0u;
-    key |= lineKey;
-
-    const uint8_t cachedPattern = patternCache[key];
+    const uint8_t cachedPattern = cache[key];
     if (cachedPattern != CACHE_UNSET) {
         return static_cast<Pattern>(cachedPattern - 1);
     }
@@ -531,15 +678,15 @@ Pattern Board::getPattern(uint32_t lineKey, Color color) {
     tie(realLen, fullLen, start, end) = countLineKey(lineKey);
 
     if (isBlack && realLen >= 6) {
-        patternCache[key] = static_cast<uint8_t>(OVERLINE) + 1;
+        cache[key] = static_cast<uint8_t>(OVERLINE) + 1;
         return OVERLINE;
     }
     else if (realLen >= 5) {
-        patternCache[key] = static_cast<uint8_t>(FIVE) + 1;
+        cache[key] = static_cast<uint8_t>(FIVE) + 1;
         return FIVE;
     }
     else if (fullLen < 5) {
-        patternCache[key] = static_cast<uint8_t>(DEAD) + 1;
+        cache[key] = static_cast<uint8_t>(DEAD) + 1;
         return DEAD;
     }
 
@@ -552,7 +699,7 @@ Pattern Board::getPattern(uint32_t lineKey, Color color) {
         if (piece == EMPTY) {
             uint32_t shiftedLineKey = shiftLineKey(lineKey, i);
             shiftedLineKey = setLineKeyPiece(shiftedLineKey, mid, self);
-            Pattern slp = getPattern(shiftedLineKey, color);
+            Pattern slp = calculatePattern(shiftedLineKey, color, cache);
         
             if (slp == FIVE && patternCnt[FIVE] < 2) {
                 fiveIdx[patternCnt[FIVE]] = i;
@@ -588,7 +735,7 @@ Pattern Board::getPattern(uint32_t lineKey, Color color) {
     else if (patternCnt[BLOCKED_2])
         p = BLOCKED_1;
     
-    patternCache[key] = static_cast<uint8_t>(p) + 1;
+    cache[key] = static_cast<uint8_t>(p) + 1;
     return p;
 }
 

--- a/android/app/src/main/java/com/renzzle_fe/cpp/game/cell.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/game/cell.h
@@ -13,6 +13,8 @@ const Score defendScore[PATTERN_SIZE + 1] = { 0, 00, 00, 00, 00, 02, 02, 02, 02,
 using PatternKey = uint16_t;
 constexpr int PATTERN_KEY_BITS = 4;
 constexpr int PATTERN_KEY_SIZE = 1 << (DIRECTION_SIZE * PATTERN_KEY_BITS);
+static_assert(PATTERN_SIZE < (1 << PATTERN_KEY_BITS),
+    "Every Pattern value must fit in one packed nibble.");
 
 inline Pattern decodePatternKey(PatternKey key, int dir) {
     return static_cast<Pattern>((key >> (dir * PATTERN_KEY_BITS)) & 0xF);
@@ -125,11 +127,9 @@ class Cell {
 
 private:
     Score score[2];
-    Pattern patterns[2][DIRECTION_SIZE];
+    PatternKey patternKeys[2];
     CompositePattern cPattern[2];
     Piece piece;
-    
-    PatternKey getPatternKey(Piece piece) const;
 
 public:
     Cell();
@@ -145,13 +145,12 @@ public:
     void updateDerived();
     
 };
+static_assert(sizeof(Cell) == 16, "Cell must stay compact.");
 
 Cell::Cell() {
     this->piece = EMPTY;
-    for(Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
-        setPattern(BLACK, dir, NONE);
-        setPattern(WHITE, dir, NONE);
-    }
+    patternKeys[BLACK] = 0;
+    patternKeys[WHITE] = 0;
     score[BLACK] = 0;
     score[WHITE] = 0;
     cPattern[BLACK] = ETC;
@@ -167,7 +166,7 @@ void Cell::setPiece(const Piece& piece) {
 }
 
 Pattern Cell::getPattern(Piece piece, Direction dir) const {
-    return patterns[piece][dir];
+    return decodePatternKey(patternKeys[piece], static_cast<int>(dir));
 }
 
 CompositePattern Cell::getCompositePattern(Piece piece) const {
@@ -179,7 +178,11 @@ Score Cell::getScore(Piece piece) const {
 }
 
 void Cell::setPattern(Piece piece, Direction dir, Pattern pattern) {
-    this->patterns[piece][dir] = pattern;
+    const int shift = static_cast<int>(dir) * PATTERN_KEY_BITS;
+    const PatternKey mask = static_cast<PatternKey>(0xFu << shift);
+    patternKeys[piece] = static_cast<PatternKey>(
+        (patternKeys[piece] & static_cast<PatternKey>(~mask))
+        | (static_cast<PatternKey>(pattern) << shift));
 }
 
 void Cell::clearCompositePattern() {
@@ -187,31 +190,23 @@ void Cell::clearCompositePattern() {
     cPattern[WHITE] = NOT_EMPTY;
 }
 
-PatternKey Cell::getPatternKey(Piece piece) const {
-    PatternKey key = 0;
-    for (int dir = 0; dir < DIRECTION_SIZE; ++dir) {
-        key |= static_cast<PatternKey>(patterns[piece][dir]) << (dir * PATTERN_KEY_BITS);
-    }
-    return key;
-}
-
 void Cell::setCompositePattern() {
-    const PatternKey blackKey = getPatternKey(BLACK);
-    const PatternKey whiteKey = getPatternKey(WHITE);
+    const PatternKey blackKey = patternKeys[BLACK];
+    const PatternKey whiteKey = patternKeys[WHITE];
     cPattern[BLACK] = blackCompositeLUT()[blackKey];
     cPattern[WHITE] = whiteCompositeLUT()[whiteKey];
 }
 
 void Cell::setScore() {
-    const PatternKey blackKey = getPatternKey(BLACK);
-    const PatternKey whiteKey = getPatternKey(WHITE);
+    const PatternKey blackKey = patternKeys[BLACK];
+    const PatternKey whiteKey = patternKeys[WHITE];
     score[BLACK] = attackScoreLUT()[blackKey] + defendScoreLUT()[whiteKey];
     score[WHITE] = attackScoreLUT()[whiteKey] + defendScoreLUT()[blackKey];
 }
 
 void Cell::updateDerived() {
-    const PatternKey blackKey = getPatternKey(BLACK);
-    const PatternKey whiteKey = getPatternKey(WHITE);
+    const PatternKey blackKey = patternKeys[BLACK];
+    const PatternKey whiteKey = patternKeys[WHITE];
     score[BLACK] = attackScoreLUT()[blackKey] + defendScoreLUT()[whiteKey];
     score[WHITE] = attackScoreLUT()[whiteKey] + defendScoreLUT()[blackKey];
     cPattern[BLACK] = blackCompositeLUT()[blackKey];

--- a/android/app/src/main/java/com/renzzle_fe/cpp/game/fixed_move_list.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/game/fixed_move_list.h
@@ -75,3 +75,5 @@ public:
         return std::vector<Pos>(begin(), end());
     }
 };
+
+using CandidateList = FixedMoveList<BOARD_SIZE * BOARD_SIZE>;

--- a/android/app/src/main/java/com/renzzle_fe/cpp/game/zobrist.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/game/zobrist.h
@@ -1,29 +1,29 @@
 #pragma once
 
-#include "board.h"
-#include <random>
+#include "pos.h"
+#include <cstdint>
 #include <mutex>
+#include <random>
 
 #define NUM_PIECE_TYPES 4
 
-static size_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
-static std::once_flag zobristInitFlag;
+inline constexpr uint64_t ZOBRIST_SEED = 0x9E3779B97F4A7C15ULL;
+inline uint64_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
+inline std::once_flag zobristInitFlag;
 
-static void initializeZobristTable() {
-    std::random_device rd;
-    std::mt19937_64 rng(rd());
-    std::uniform_int_distribution<size_t> dist(0, std::numeric_limits<size_t>::max());
+inline void initializeZobristTable() {
+    std::mt19937_64 rng(ZOBRIST_SEED);
 
     for (int i = 0; i <= BOARD_SIZE + 1; ++i) {
         for (int j = 0; j <= BOARD_SIZE + 1; ++j) {
             for (int k = 0; k < NUM_PIECE_TYPES; ++k) {
-                zobristTable[i][j][k] = dist(rng);
+                zobristTable[i][j][k] = rng();
             }
         }
     }
 }
 
-static size_t getZobristValue(int x, int y, Piece piece) {
+inline uint64_t getZobristValue(int x, int y, Piece piece) {
     std::call_once(zobristInitFlag, initializeZobristTable);
     return zobristTable[x][y][piece];
 }

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/core.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/core.h
@@ -304,6 +304,25 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
         state.lastRootStats.clear();
     }
 
+    // mate-distance pruning: an ongoing position can never win faster than
+    // WIN(1) (game ends on the very next move) nor lose faster than LOSE(0).
+    // If the window already guarantees an equal-or-faster result, this subtree
+    // cannot change the outcome — return the bound before paying for TT probes,
+    // Evaluator construction, and child moves. Terminal positions are excluded:
+    // they may evaluate to WIN(0)/LOSE(0) and are handled by isGameOver below.
+    if (board.getResult() == ONGOING) {
+        Value fastestWin(Value::Result::WIN, 1);
+        if (alpha >= fastestWin) {
+            fastestWin.setType(Value::Type::UPPER_BOUND);
+            return fastestWin;
+        }
+        Value fastestLose(Value::Result::LOSE, 0);
+        if (beta <= fastestLose) {
+            fastestLose.setType(Value::Type::LOWER_BOUND);
+            return fastestLose;
+        }
+    }
+
     const Value originalAlpha = alpha;
     const Value originalBeta = beta;
 

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/core.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/core.h
@@ -131,8 +131,9 @@ Search::ChildSearchResult Search::searchChildPVS(int depth, bool isMax, size_t m
     nextBestVal.decreaseResultDepth();
 
     if (moveIndex == 0) {
-        result.value = abp(depth - 1, !isMax, nextAlpha, nextBeta, &result.pv);
-        result.hasExactPV = result.value.getType() == Value::Type::EXACT;
+        MoveList* childPV = pv != nullptr ? &result.pv : nullptr;
+        result.value = abp(depth - 1, !isMax, nextAlpha, nextBeta, childPV);
+        result.hasExactPV = childPV != nullptr && result.value.getType() == Value::Type::EXACT;
         return result;
     }
 
@@ -237,7 +238,8 @@ Value Search::finalizeNodeValue(bool isMax, Value originalAlpha, Value originalB
     return result;
 }
 
-void Search::updateHistoryFromNode(int depth, const Pos& bestMove, const MoveList& searchedMoves,
+void Search::updateHistoryFromNode(int depth, const Pos& bestMove,
+    const uint8_t* searchedMoveCodes, size_t searchedMoveCount,
     bool causedCutoff, Value result, bool sideToMoveIsBlack) {
     if (!searchActive() || bestMove.isDefault()) {
         return;
@@ -246,9 +248,18 @@ void Search::updateHistoryFromNode(int depth, const Pos& bestMove, const MoveLis
     const int bonus = std::max(1, std::min(depth * depth, 256));
     if (causedCutoff || result.getType() == Value::Type::LOWER_BOUND) {
         updateHistoryScore(bestMove, sideToMoveIsBlack, bonus);
+        // killer slots only remember cutoff moves that make at least a four for the
+        // mover: those transfer to sibling nodes, while quiet cutoff moves would just
+        // displace the static block-the-biggest-threat order and grow the tree
+        if (board.getCell(bestMove).getScore(sideToMoveIsBlack ? BLACK : WHITE)
+            >= KILLER_MIN_FOUR_SCORE) {
+            updateKillerMove(getSearchPly(), packMoveCode(bestMove));
+        }
 
         const int penalty = std::max(1, bonus / 2);
-        for (const Pos& move : searchedMoves) {
+        for (size_t i = 0; i < searchedMoveCount; ++i) {
+            const uint8_t code = searchedMoveCodes[i];
+            const Pos move(code >> 4, code & 0x0F);
             if (!(move == bestMove)) {
                 updateHistoryScore(move, sideToMoveIsBlack, -penalty);
             }
@@ -326,7 +337,7 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
     // applying it in DEFENSIVE mode would invent false LOSE/WIN at quiet positions.
     const bool threatBrokenLeaf = options.mode == Mode::VCT
         && !attackerTurn && !evaluator.isOppoMateExist();
-    MoveList moves = getCandidates(evaluator, isMax);
+    CandidateList moves = getCandidates(evaluator, isMax);
     if (moves.empty()) {
         return threatBrokenLeaf
             ? evaluateThreatBrokenLeaf(isMax, depth)
@@ -342,8 +353,8 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
         : Value(MAX_VALUE + 1, Value::Type::UNKNOWN);
     Pos bestMove;
     MoveList bestChildPV;
-    MoveList searchedMoves;
-    searchedMoves.reserve(moves.size());
+    uint8_t searchedMoveCodes[BOARD_SIZE * BOARD_SIZE];
+    size_t searchedMoveCount = 0;
 
     const int shallowMoveLimit = getShallowMoveLimit(evaluator, depth, attackerTurn);
     const bool sideToMoveIsBlack = board.isBlackTurn();
@@ -366,7 +377,8 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
         tt.prefetch(getTTKey(board));
 
         searchedAny = true;
-        searchedMoves.push_back(move);
+        searchedMoveCodes[searchedMoveCount++] =
+            static_cast<uint8_t>((move.getX() << 4) | move.getY());
         recordNodeVisit();
         const size_t nodeCountBeforeMove = isRootNode ? monitor.getVisitCnt() : 0;
         const double elapsedBeforeMove = isRootNode ? monitor.getElapsedTime() : 0.0;
@@ -409,7 +421,8 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
     }
 
     Value result = finalizeNodeValue(isMax, originalAlpha, originalBeta, alpha, beta, bestVal);
-    updateHistoryFromNode(depth, bestMove, searchedMoves, causedCutoff, result, sideToMoveIsBlack);
+    updateHistoryFromNode(depth, bestMove, searchedMoveCodes, searchedMoveCount,
+        causedCutoff, result, sideToMoveIsBlack);
 
     if (searchActive()) {
         storeTT(board, result, depth, bestMove);
@@ -423,8 +436,8 @@ Value Search::evaluateNode(Evaluator& evaluator) {
     return evaluator.evaluateTactical();
 }
 
-MoveList Search::getCandidates(Evaluator& evaluator, bool isMax) {
-    MoveList moves;
+CandidateList Search::getCandidates(Evaluator& evaluator, bool isMax) {
+    CandidateList moves;
 
     Pos sureMove = evaluator.getSureMove();
     if (!sureMove.isDefault()) {
@@ -438,21 +451,24 @@ MoveList Search::getCandidates(Evaluator& evaluator, bool isMax) {
         const bool atRoot = (board.getPath().size() == rootBoard.getPath().size());
 
         if (evaluator.isOppoMateExist()) {
-            moves = evaluator.getThreatDefend();
-            MoveList fours = evaluator.getFours();
-            moves.insert(moves.end(), fours.begin(), fours.end());
+            evaluator.getThreatDefend(moves);
+            CandidateList fours;
+            evaluator.getFours(fours);
+            appendUniqueMoves(moves, fours);
         } else if (evaluator.isOppoFourThreeExist()) {
-            moves = evaluator.getFourThreeDefend();
-            MoveList fours = evaluator.getFours();
-            moves.insert(moves.end(), fours.begin(), fours.end());
+            evaluator.getFourThreeDefend(moves);
+            CandidateList fours;
+            evaluator.getFours(fours);
+            appendUniqueMoves(moves, fours);
         } else {
             if (atRoot) {
-                moves = evaluator.getCandidates();
+                evaluator.getCandidates(moves);
                 return moves;
             }
-            moves = evaluator.getThreats();
-            MoveList makers = evaluator.getFourThreeMakers();
-            moves.insert(moves.end(), makers.begin(), makers.end());
+            evaluator.getThreats(moves);
+            CandidateList makers;
+            evaluator.getFourThreeMakers(makers);
+            appendUniqueMoves(moves, makers);
         }
         return moves;
     }
@@ -460,42 +476,64 @@ MoveList Search::getCandidates(Evaluator& evaluator, bool isMax) {
     if (options.mode == Mode::VCT) {
         const bool attackerTurn = (board.isBlackTurn() == rootBoard.isBlackTurn());
         if (attackerTurn) {
-            moves = evaluator.getThreats();
-            MoveList makers = evaluator.getFourThreeMakers();
-            moves.insert(moves.end(), makers.begin(), makers.end());
+            evaluator.getThreats(moves);
+            CandidateList makers;
+            evaluator.getFourThreeMakers(makers);
+            appendUniqueMoves(moves, makers);
         } else if (evaluator.isOppoMateExist()) {
-            moves = evaluator.getThreatDefend();
-            MoveList fours = evaluator.getFours();
-            moves.insert(moves.end(), fours.begin(), fours.end());
+            evaluator.getThreatDefend(moves);
+            CandidateList fours;
+            evaluator.getFours(fours);
+            appendUniqueMoves(moves, fours);
         } else if (evaluator.isOppoFourThreeExist()) {
-            moves = evaluator.getFourThreeDefend();
-            MoveList fours = evaluator.getFours();
-            moves.insert(moves.end(), fours.begin(), fours.end());
+            evaluator.getFourThreeDefend(moves);
+            CandidateList fours;
+            evaluator.getFours(fours);
+            appendUniqueMoves(moves, fours);
         }
     }
 
     return moves;
 }
 
-void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
+void Search::appendUniqueMoves(CandidateList& moves, const CandidateList& extraMoves) const {
+    if (extraMoves.empty()) {
+        return;
+    }
+
+    moves.reserve(moves.size() + extraMoves.size());
+    for (const Pos& move : extraMoves) {
+        if (std::find(moves.begin(), moves.end(), move) == moves.end()) {
+            moves.push_back(move);
+        }
+    }
+}
+
+void Search::sortChildNodes(CandidateList& moves, bool isMax, const TTEntry* entry) {
     if (moves.size() < 2) {
         return;
     }
 
     struct MoveOrderInfo {
-        Pos move;
+        uint8_t moveCode;
         bool isTTBest;
         bool hasTT;
         int flagPriority;
         int32_t ttScore;
         int historyScore;
         int cellScore;
+        int killerRank;
     };
 
     const Pos ttBestMove = (entry != nullptr && entry->bestMove != TranspositionTable::INVALID_MOVE)
         ? TranspositionTable::decodeMove(entry->bestMove)
         : Pos();
     const bool sideToMoveIsBlack = board.isBlackTurn();
+    const size_t searchPly = getSearchPly();
+    const uint8_t killerCode0 =
+        searchPly < state.killerMoves.size() ? state.killerMoves[searchPly][0] : 0;
+    const uint8_t killerCode1 =
+        searchPly < state.killerMoves.size() ? state.killerMoves[searchPly][1] : 0;
     bool hasHistorySignal = false;
 
     for (const Pos& move : moves) {
@@ -524,8 +562,8 @@ void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
         return 2;
     };
 
-    vector<MoveOrderInfo> infos;
-    infos.reserve(moves.size());
+    MoveOrderInfo infos[BOARD_SIZE * BOARD_SIZE];
+    size_t infoCount = 0;
 
     // Attacker (isMax) prefers self-attack score; defender wants to block opponent's most
     // threatening spot, so uses opponent's score. Matches the evaluator's previous sort intent.
@@ -545,17 +583,25 @@ void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
                 ? &childEntryStorage
                 : nullptr;
         MoveOrderInfo info;
-        info.move = move;
+        info.moveCode = static_cast<uint8_t>((move.getX() << 4) | move.getY());
         info.isTTBest = !ttBestMove.isDefault() && move == ttBestMove;
         info.hasTT = childEntry != nullptr;
         info.flagPriority = childEntry != nullptr ? getValueTypePriority(childEntry->getFlag()) : getValueTypePriority(TTFlag::NONE);
         info.ttScore = childEntry != nullptr ? childEntry->score : 0;
         info.historyScore = getHistoryScore(move, sideToMoveIsBlack);
         info.cellScore = board.getCell(move).getScore(scorePiece);
-        infos.push_back(info);
+        info.killerRank = 0;
+        if (info.moveCode == killerCode0 || info.moveCode == killerCode1) {
+            // stored killers made a four where they cut off; re-validate on this
+            // board since the same cell may no longer make one here
+            if (board.getCell(move).getScore(sideToMovePiece) >= KILLER_MIN_FOUR_SCORE) {
+                info.killerRank = info.moveCode == killerCode0 ? 2 : 1;
+            }
+        }
+        infos[infoCount++] = info;
     }
 
-    std::stable_sort(infos.begin(), infos.end(), [&](const MoveOrderInfo& a, const MoveOrderInfo& b) {
+    std::stable_sort(infos, infos + infoCount, [&](const MoveOrderInfo& a, const MoveOrderInfo& b) {
         if (a.isTTBest != b.isTTBest) {
             return a.isTTBest;
         }
@@ -572,6 +618,11 @@ void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
         if (a.flagPriority != b.flagPriority) {
             return a.flagPriority < b.flagPriority;
         }
+        // recent four-making cutoff moves outrank the static cell score: they either
+        // refute the line the same way they refuted a sibling, or fail fast (forcing)
+        if (a.killerRank != b.killerRank) {
+            return a.killerRank > b.killerRank;
+        }
         if (a.cellScore != b.cellScore) {
             return a.cellScore > b.cellScore;
         }
@@ -582,7 +633,8 @@ void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
     });
 
     for (size_t i = 0; i < moves.size(); ++i) {
-        moves[i] = infos[i].move;
+        const uint8_t code = infos[i].moveCode;
+        moves[i] = Pos(code >> 4, code & 0x0F);
     }
 }
 

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/core.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/core.h
@@ -9,13 +9,20 @@ bool Search::tryResolveFromTT(int depth, Value& alpha, Value& beta, MoveList* pv
         return false;
     }
 
+    // root: keep ttEntry for move ordering only — never resolve or tighten the
+    // window from it. The root's own stale bound (e.g. an UPPER_BOUND left by a
+    // failed aspiration window) can shrink beta enough that the first move causes
+    // a cutoff, leaving lastRootStats partial and the PV rebuilt from stale TT
+    // breadcrumbs instead of a verified line.
+    const bool isRootNode = board.getPath().size() == rootBoard.getPath().size();
+    if (isRootNode) {
+        return false;
+    }
+
     Value ttValue = getTTValue(*ttEntry);
     const TTFlag ttFlag = ttEntry->getFlag();
-    const bool isRootNode = board.getPath().size() == rootBoard.getPath().size();
-    const bool allowTerminalExactDepthBypass = !isRootNode;
 
-    if (allowTerminalExactDepthBypass &&
-        ttFlag == TTFlag::EXACT &&
+    if (ttFlag == TTFlag::EXACT &&
         (ttValue.isWin() || ttValue.isLose())) {
         if (pv != nullptr) {
             appendTTPV(board, *pv);
@@ -302,6 +309,7 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
     const bool isRootNode = board.getPath().size() == rootBoard.getPath().size();
     if (isRootNode) {
         state.lastRootStats.clear();
+        state.lastRootSearchComplete = false;
     }
 
     // mate-distance pruning: an ongoing position can never win faster than
@@ -383,9 +391,11 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
 
     bool searchedAny = false;
     bool causedCutoff = false;
+    bool searchedAll = true;
 
     for (size_t i = 0; i < moves.size(); ++i) {
         if (static_cast<int>(i) >= shallowMoveLimit) {
+            searchedAll = false;
             break;
         }
 
@@ -407,6 +417,7 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
 
         board.undo();
         if (!searchActive()) {
+            searchedAll = false;
             break;
         }
 
@@ -431,8 +442,13 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
 
         if (moveCausedCutoff) {
             causedCutoff = true;
+            searchedAll = false;
             break;
         }
+    }
+
+    if (isRootNode) {
+        state.lastRootSearchComplete = searchedAny && searchedAll;
     }
 
     if (!searchedAny) {

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/history.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/history.h
@@ -27,4 +27,27 @@ void Search::clearHistory() {
     for (auto& sideHistory : state.historyScores) {
         sideHistory.fill(0);
     }
+    for (auto& killers : state.killerMoves) {
+        killers.fill(0);
+    }
+}
+
+size_t Search::getSearchPly() {
+    return board.getPath().size() - rootBoard.getPath().size();
+}
+
+uint8_t Search::packMoveCode(const Pos& move) {
+    return static_cast<uint8_t>((move.getX() << 4) | move.getY());
+}
+
+void Search::updateKillerMove(size_t ply, uint8_t moveCode) {
+    if (ply >= state.killerMoves.size() || moveCode == 0) {
+        return;
+    }
+
+    auto& killers = state.killerMoves[ply];
+    if (killers[0] != moveCode) {
+        killers[1] = killers[0];
+        killers[0] = moveCode;
+    }
 }

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/lifecycle.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/lifecycle.h
@@ -137,7 +137,8 @@ size_t Search::getEstimatedMemoryBytes() const {
     return tt.getMemoryBytes()
         + (sizeof(Board) * 2)
         + (state.bestPath.capacity() * sizeof(Pos))
-        + sizeof(state.historyScores);
+        + sizeof(state.historyScores)
+        + sizeof(state.killerMoves);
 }
 
 const std::vector<Search::RootMoveStat>& Search::getLastRootStats() const {

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/lifecycle.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/lifecycle.h
@@ -4,6 +4,7 @@ void Search::ids() {
     state.isRunning = true;
     state.bestPath.clear();
     state.bestValue = Value();
+    state.lastRootSearchComplete = false;
     state.nodesSinceMonitorPoll = 0;
     state.qvcfDisabledAfterWin = false;
     clearHistory();
@@ -37,8 +38,10 @@ void Search::ids() {
         }
 
         // DEFENSIVE elimination: if exactly one root candidate is non-LOSE,
-        // the answer is decided regardless of further deepening.
-        if (options.mode == Mode::DEFENSIVE) {
+        // the answer is decided regardless of further deepening. Only valid when
+        // the last root call actually searched every candidate — a partial
+        // lastRootStats (root cutoff/stop) says nothing about unsearched moves.
+        if (options.mode == Mode::DEFENSIVE && state.lastRootSearchComplete) {
             int nonLoseCount = 0;
             for (auto& stat : state.lastRootStats) {
                 if (!stat.value.isLose()) {

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/qvcf.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/detail/qvcf.h
@@ -33,7 +33,7 @@ bool Search::enterQVCFNode(QVCFContext& context) {
     return true;
 }
 
-void Search::moveQVCFTTBestFirst(MoveList& moves, const Pos& bestMove) const {
+void Search::moveQVCFTTBestFirst(CandidateList& moves, const Pos& bestMove) const {
     if (bestMove.isDefault()) {
         return;
     }
@@ -197,7 +197,8 @@ Value Search::qvcfAttack(int remainingPly, QVCFContext& context, MoveList* pv) {
         return Value();
     }
 
-    MoveList moves = evaluator.getFours();
+    CandidateList moves;
+    evaluator.getFours(moves);
     moveQVCFTTBestFirst(moves, cachedBestMove);
     if (moves.empty()) {
         storeQVCFFail(board, remainingPly);

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/search.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/search.h
@@ -62,6 +62,8 @@ PRIVATE
         Value bestValue;
         std::vector<RootMoveStat> lastRootStats;
         std::array<std::array<int, BOARD_SIZE * BOARD_SIZE>, 2> historyScores = {};
+        // two killer slots per ply from root; entries are packed (x<<4)|y codes, 0 = empty
+        std::array<std::array<uint8_t, 2>, BOARD_SIZE * BOARD_SIZE + 4> killerMoves = {};
         size_t nodesSinceMonitorPoll = 0;
     };
 
@@ -83,13 +85,17 @@ PRIVATE
     static constexpr uint64_t QVCF_TT_KEY = 0x6a09e667f3bcc909ULL;
     static constexpr int QVCF_HEURISTIC_WIN_SCORE = MAX_VALUE - (BOARD_SIZE * BOARD_SIZE) - 1024;
     static constexpr int HISTORY_ABS_LIMIT = 16384;
+    // attackScore[B4] — a killer must make at least a four (for the mover) to be
+    // stored and to outrank the static cell score during move ordering
+    static constexpr int KILLER_MIN_FOUR_SCORE = 400;
     static constexpr int ASPIRATION_START_DELTA = 32;
     Value abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv = nullptr);
     Value searchRootWithAspiration(int depth, MoveList* pv);
     Value evaluateNode(Evaluator& evaluator);
     bool searchActive() const;
-    MoveList getCandidates(Evaluator& evaluator, bool isMax);
-    void sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry);
+    CandidateList getCandidates(Evaluator& evaluator, bool isMax);
+    void appendUniqueMoves(CandidateList& moves, const CandidateList& extraMoves) const;
+    void sortChildNodes(CandidateList& moves, bool isMax, const TTEntry* entry);
     bool isGameOver(Board& board);
     uint64_t getTTKey(Board& board) const;
     uint64_t getChildTTKey(const Pos& move);
@@ -106,6 +112,9 @@ PRIVATE
     int getHistoryScore(const Pos& move, bool isBlackTurn) const;
     void updateHistoryScore(const Pos& move, bool isBlackTurn, int delta);
     void clearHistory();
+    size_t getSearchPly();
+    static uint8_t packMoveCode(const Pos& move);
+    void updateKillerMove(size_t ply, uint8_t moveCode);
     bool tryResolveFromTT(int depth, Value& alpha, Value& beta, MoveList* pv,
         TTEntry& ttEntryStorage, const TTEntry*& ttEntry, Value& resolvedValue);
     int getShallowMoveLimit(Evaluator& evaluator, int depth, bool attackerTurn);
@@ -121,7 +130,8 @@ PRIVATE
         size_t nodeCountBeforeMove, double elapsedBeforeMove, const Pos& ttBestMove);
     Value finalizeNodeValue(bool isMax, Value originalAlpha, Value originalBeta,
         Value alpha, Value beta, Value bestVal) const;
-    void updateHistoryFromNode(int depth, const Pos& bestMove, const MoveList& searchedMoves,
+    void updateHistoryFromNode(int depth, const Pos& bestMove,
+        const uint8_t* searchedMoveCodes, size_t searchedMoveCount,
         bool causedCutoff, Value result, bool sideToMoveIsBlack);
     void rebuildPV(const Pos& bestMove, const MoveList& bestChildPV, Value result, MoveList* pv) const;
     void completeWinPV(Value value, MoveList& pv);
@@ -129,7 +139,7 @@ PRIVATE
     Result getRootWinResult();
     uint64_t getQVCFTTKey(Board& targetBoard) const;
     bool enterQVCFNode(QVCFContext& context);
-    void moveQVCFTTBestFirst(MoveList& moves, const Pos& bestMove) const;
+    void moveQVCFTTBestFirst(CandidateList& moves, const Pos& bestMove) const;
     bool probeQVCFTT(Board& targetBoard, int remainingPly, Value& value, Pos& bestMove) const;
     void storeQVCFWin(Board& targetBoard, Value value, int remainingPly, const Pos& bestMove);
     void storeQVCFFail(Board& targetBoard, int remainingPly);

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/search.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/search.h
@@ -61,6 +61,9 @@ PRIVATE
         MoveList bestPath;
         Value bestValue;
         std::vector<RootMoveStat> lastRootStats;
+        // true only when the last root abp call searched every root candidate
+        // (no cutoff, no truncation, not stopped) — lastRootStats covers all moves
+        bool lastRootSearchComplete = false;
         std::array<std::array<int, BOARD_SIZE * BOARD_SIZE>, 2> historyScores = {};
         // two killer slots per ply from root; entries are packed (x<<4)|y codes, 0 = empty
         std::array<std::array<uint8_t, 2>, BOARD_SIZE * BOARD_SIZE + 4> killerMoves = {};

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/search_win.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/search_win.h
@@ -26,7 +26,7 @@ PRIVATE
     bool isTargetTurn();
     uint64_t getTTKey();
     uint8_t getDepthLeft();
-    void moveTTBestFirst(MoveList& moves, const TTEntry* entry);
+    void moveTTBestFirst(CandidateList& moves, const TTEntry* entry);
 
 PUBLIC
     SearchWin(Board& board, SearchMonitor& monitor);
@@ -71,7 +71,12 @@ bool SearchWin::dfsVCF() {
     monitor.incVisitCnt();
 
     Evaluator evaluator(board);
-    MoveList moves = isTargetTurn() ? evaluator.getFours() : evaluator.getCandidates();
+    CandidateList moves;
+    if (isTargetTurn()) {
+        evaluator.getFours(moves);
+    } else {
+        evaluator.getCandidates(moves);
+    }
     moveTTBestFirst(moves, probed);
 
     for (const auto& move : moves) {
@@ -144,7 +149,7 @@ uint8_t SearchWin::getDepthLeft() {
     return static_cast<uint8_t>(remain);
 }
 
-void SearchWin::moveTTBestFirst(MoveList& moves, const TTEntry* entry) {
+void SearchWin::moveTTBestFirst(CandidateList& moves, const TTEntry* entry) {
     if (entry == nullptr) return;
     if (entry->bestMove == TranspositionTable::INVALID_MOVE) return;
 

--- a/android/app/src/main/java/com/renzzle_fe/cpp/search/vcf_candidate_finder.h
+++ b/android/app/src/main/java/com/renzzle_fe/cpp/search/vcf_candidate_finder.h
@@ -59,7 +59,7 @@ PRIVATE
     static double getElapsedSeconds(const VCFProbeContext& context);
     static bool isWin(Board& board, VCFProbeContext& context);
     static uint64_t getVCFTTKey(Board& board);
-    static void moveTTBestFirst(MoveList& moves, const TTEntry* entry);
+    static void moveTTBestFirst(CandidateList& moves, const TTEntry* entry);
     bool shouldStopProbe(VCFProbeContext& context) const;
     bool dfsVCF(Board& board, VCFProbeContext& context);
     bool probeRootVCF(Board& probeBoard, VCFCandidateProbeResult* probeResult);
@@ -155,7 +155,7 @@ uint64_t VCFCandidateFinder::getVCFTTKey(Board& board) {
     return key;
 }
 
-void VCFCandidateFinder::moveTTBestFirst(MoveList& moves, const TTEntry* entry) {
+void VCFCandidateFinder::moveTTBestFirst(CandidateList& moves, const TTEntry* entry) {
     if (entry == nullptr) return;
     if (entry->bestMove == TranspositionTable::INVALID_MOVE) return;
 
@@ -212,9 +212,12 @@ bool VCFCandidateFinder::dfsVCF(Board& board, VCFProbeContext& context) {
     }
 
     Evaluator evaluator(board);
-    MoveList moves = isTargetTurn(board, context.targetColor)
-        ? evaluator.getFours()
-        : evaluator.getCandidates();
+    CandidateList moves;
+    if (isTargetTurn(board, context.targetColor)) {
+        evaluator.getFours(moves);
+    } else {
+        evaluator.getCandidates(moves);
+    }
     moveTTBestFirst(moves, ttEntry);
 
     for (const Pos& nextMove : moves) {
@@ -335,7 +338,9 @@ MoveList VCFCandidateFinder::findFromCandidates(const MoveList& candidates) {
 MoveList VCFCandidateFinder::findFromEvaluatorCandidates() {
     Board board(rootBoard);
     Evaluator evaluator(board);
-    return findFromCandidates(evaluator.getCandidates());
+    CandidateList candidates;
+    evaluator.getCandidates(candidates);
+    return findFromCandidates(candidates.toMoveList());
 }
 
 MoveList VCFCandidateFinder::findFromAllLegalMoves() {

--- a/ios/cpp/engine/engine.h
+++ b/ios/cpp/engine/engine.h
@@ -156,7 +156,8 @@ FindNextMoveAnalysis analyzeNextMove(string boardStr, EngineCancelToken* cancelT
     }
 
     // safety net: no completed iteration → pick any reasonable candidate
-    MoveList moves = evaluator.getCandidates();
+    CandidateList moves;
+    evaluator.getCandidates(moves);
     if (!moves.empty()) {
         Pos fallback = moves[0];
         analysis.move = convertMoveToInt(fallback);

--- a/ios/cpp/evaluate/evaluator.h
+++ b/ios/cpp/evaluate/evaluator.h
@@ -14,9 +14,6 @@ PRIVATE
     Piece self = BLACK;
     Piece oppo = WHITE;
 
-    const MoveBucket* patternMap[2][COMPOSITE_PATTERN_SIZE] = {};
-
-    void classify();
     int evaluatePatternBalance();
     const MoveBucket& bucket(Piece piece, CompositePattern pattern) const;
     bool hasPattern(Piece piece, CompositePattern pattern) const;
@@ -27,12 +24,18 @@ PUBLIC
     Evaluator(Board& board);
     Value quickWinCheck(Pos* bestMove = nullptr);
     MoveList getCandidates();
+    void getCandidates(CandidateList& result);
     Pos getSureMove();
     MoveList getFours();
+    void getFours(CandidateList& result);
     MoveList getThreats();
+    void getThreats(CandidateList& result);
     MoveList getThreatDefend();
+    void getThreatDefend(CandidateList& result);
     MoveList getFourThreeMakers();
+    void getFourThreeMakers(CandidateList& result);
     MoveList getFourThreeDefend();
+    void getFourThreeDefend(CandidateList& result);
     Pos getOppoWinningDefend();
     bool isOppoMateExist();
     bool isOppoFourThreeExist();
@@ -94,12 +97,13 @@ inline Value evaluateTacticalSummary(Board& board) {
     return Value(val);
 }
 
-Evaluator::Evaluator(Board& board) : board(board) {
-    classify();
-}
+Evaluator::Evaluator(Board& board)
+    : board(board),
+      self(board.isBlackTurn() ? BLACK : WHITE),
+      oppo(board.isBlackTurn() ? WHITE : BLACK) {}
 
 const MoveBucket& Evaluator::bucket(Piece piece, CompositePattern pattern) const {
-    return *patternMap[piece][pattern];
+    return board.getPatternBucket(piece, pattern);
 }
 
 bool Evaluator::hasPattern(Piece piece, CompositePattern pattern) const {
@@ -116,18 +120,6 @@ bool Evaluator::hasFourLevelPressure(Piece piece) const {
 
 int Evaluator::patternCount(Piece piece, CompositePattern pattern) const {
     return bucket(piece, pattern).size();
-}
-
-void Evaluator::classify() {
-    self = board.isBlackTurn() ? BLACK : WHITE;
-    oppo = !board.isBlackTurn() ? BLACK : WHITE;
-
-    for (int color = 0; color < 2; ++color) {
-        for (int pattern = 0; pattern < COMPOSITE_PATTERN_SIZE; ++pattern) {
-            patternMap[color][pattern] =
-                &board.getPatternBucket(static_cast<Piece>(color), static_cast<CompositePattern>(pattern));
-        }
-    }
 }
 
 int Evaluator::evaluatePatternBalance() {
@@ -237,16 +229,23 @@ Value Evaluator::quickWinCheck(Pos* bestMove) {
 }
 
 MoveList Evaluator::getCandidates() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getCandidates(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getCandidates(CandidateList& result) {
+    result.clear();
 
     Pos sureMove = getSureMove();
     if (!sureMove.isDefault()) {
         result.push_back(sureMove);
-        return result.toMoveList();
+        return;
     }
 
     if (isOppoMateExist()) {
-        return getThreatDefend();
+        getThreatDefend(result);
+        return;
     }
 
     result.reserve(
@@ -278,8 +277,6 @@ MoveList Evaluator::getCandidates() {
     sort(result.begin(), result.end(), [&](const Pos& a, const Pos& b) {
         return board.getCell(a).getScore(self) > board.getCell(b).getScore(self);
     });
-
-    return result.toMoveList();
 }
 
 Pos Evaluator::getSureMove() {
@@ -287,7 +284,7 @@ Pos Evaluator::getSureMove() {
         return board.getFirstPatternPos(self, WINNING);
     }
     if (board.hasCompositePattern(oppo, WINNING)) {
-        MoveList result;
+        CandidateList result;
         result.reserve(board.getCompositePatternCount(oppo, WINNING));
         bucket(oppo, WINNING).forEach([&](const Pos& p) {
             if (!isMoveForbidden(p)) result.push_back(p);
@@ -314,14 +311,20 @@ Pos Evaluator::getSureMove() {
 }
 
 MoveList Evaluator::getFours() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getFours(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getFours(CandidateList& result) {
+    result.clear();
     if (hasPattern(self, WINNING)) {
-        result.push_back(bucket(self, WINNING).front()); 
-        return result.toMoveList();
+        result.push_back(bucket(self, WINNING).front());
+        return;
     }
     if (hasPattern(self, MATE)) {
         result.push_back(bucket(self, MATE).front());
-        return result.toMoveList();
+        return;
     }
     result.reserve(
         patternCount(self, B4_F3) +
@@ -334,19 +337,23 @@ MoveList Evaluator::getFours() {
     stable_sort(result.begin(), result.end(), [&](const Pos& a, const Pos& b) {
         return board.getCell(a).getScore(oppo) > board.getCell(b).getScore(oppo);
     });
-
-    return result.toMoveList();
 }
 
 MoveList Evaluator::getThreats() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getThreats(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getThreats(CandidateList& result) {
+    result.clear();
     if (hasPattern(self, WINNING)) {
         result.push_back(bucket(self, WINNING).front());
-        return result.toMoveList();
+        return;
     }
     if (hasPattern(self, MATE)) {
         result.push_back(bucket(self, MATE).front());
-        return result.toMoveList();
+        return;
     }
     result.reserve(
         patternCount(self, B4_F3) +
@@ -363,11 +370,16 @@ MoveList Evaluator::getThreats() {
     bucket(self, B4_ANY).forEach([&](const Pos& p) { result.push_back(p); });
 
     // sort omitted — Search::sortChildNodes handles ordering uniformly (cellScore + TT/history)
-    return result.toMoveList();
 }
 
 MoveList Evaluator::getThreatDefend() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getThreatDefend(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getThreatDefend(CandidateList& result) {
+    result.clear();
     array<uint8_t, 256> seen = {};
     auto appendUniqueLegal = [&](const Pos& p) {
         if (isMoveForbidden(p)) return;
@@ -377,7 +389,7 @@ MoveList Evaluator::getThreatDefend() {
         result.push_back(p);
     };
 
-    if (!isOppoMateExist()) return result.toMoveList();
+    if (!isOppoMateExist()) return;
 
     if (hasPattern(oppo, WINNING)) {
         result.reserve(patternCount(oppo, WINNING));
@@ -385,7 +397,7 @@ MoveList Evaluator::getThreatDefend() {
             appendUniqueLegal(p);
         });
         if (!result.empty()) {
-            return result.toMoveList();
+            return;
         }
     }
 
@@ -443,7 +455,7 @@ MoveList Evaluator::getThreatDefend() {
                     Pos cp(r, c);
                     if (!isMoveForbidden(cp)) {
                         result.push_back(cp);
-                        return result.toMoveList();
+                        return;
                     }
                 }
             }
@@ -451,11 +463,16 @@ MoveList Evaluator::getThreatDefend() {
     }
 
     // sort omitted — Search::sortChildNodes handles ordering uniformly (cellScore + TT/history)
-    return result.toMoveList();
 }
 
 MoveList Evaluator::getFourThreeMakers() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getFourThreeMakers(result);
+    return result.toMoveList();
+}
+
+void Evaluator::getFourThreeMakers(CandidateList& result) {
+    result.clear();
     array<uint8_t, 256> seen = {};
 
     auto appendUniqueLegal = [&](const Pos& p) {
@@ -531,13 +548,18 @@ MoveList Evaluator::getFourThreeMakers() {
     });
 
     // sort omitted — Search::sortChildNodes handles ordering uniformly (cellScore + TT/history)
-    return result.toMoveList();
 }
 
 MoveList Evaluator::getFourThreeDefend() {
-    FixedMoveList<BOARD_SIZE * BOARD_SIZE> result;
+    CandidateList result;
+    getFourThreeDefend(result);
+    return result.toMoveList();
+}
 
-    if (!isOppoFourThreeExist()) return result.toMoveList();
+void Evaluator::getFourThreeDefend(CandidateList& result) {
+    result.clear();
+
+    if (!isOppoFourThreeExist()) return;
 
     const int b43Count = patternCount(oppo, B4_F3);
 
@@ -669,7 +691,7 @@ MoveList Evaluator::getFourThreeDefend() {
             seen[k] = 1;
             result.push_back(p);
         });
-        return result.toMoveList();
+        return;
     }
 
     // If multiple B4_F3's exist, only the intersection of their defenses can effectively block all forks
@@ -700,7 +722,6 @@ MoveList Evaluator::getFourThreeDefend() {
     }
 
     // sort omitted — Search::sortChildNodes handles ordering uniformly (cellScore + TT/history)
-    return result.toMoveList();
 }
 
 Pos Evaluator::getOppoWinningDefend() {

--- a/ios/cpp/game/board.h
+++ b/ios/cpp/game/board.h
@@ -21,11 +21,32 @@ PRIVATE
     static constexpr int BIT_DIAG_SIZE = (BIT_LINE_SIZE * 2) - 1;
     static constexpr uint64_t LINE_KEY_MASK = (1ull << (LINE_LENGTH * 2)) - 1ull;
     static constexpr int CENTER_SHIFT = (LINE_LENGTH / 2) * 2;
+    static constexpr int PATTERN_CACHE_COLOR_SHIFT = LINE_LENGTH * 2;
+    static constexpr size_t PATTERN_CACHE_SIZE = 1ull << (PATTERN_CACHE_COLOR_SHIFT + 1);
+
+    struct PatternUndo {
+        uint8_t cellCode = 0;
+        Direction direction = HORIZONTAL;
+        Pattern blackPattern = NONE;
+        Pattern whitePattern = NONE;
+    };
+    static_assert(sizeof(PatternUndo) == 4, "PatternUndo must stay compact.");
+
+    struct BoardUndo {
+        Result previousResult = ONGOING;
+        std::array<Pattern, DIRECTION_SIZE> targetBlackPatterns = {};
+        std::array<Pattern, DIRECTION_SIZE> targetWhitePatterns = {};
+        std::array<PatternUndo, LINE_LENGTH * DIRECTION_SIZE> changedPatterns = {};
+        uint8_t changedPatternCount = 0;
+    };
+
+    using PatternCache = std::array<uint8_t, PATTERN_CACHE_SIZE>;
 
     CellArray cells;
     MoveList path;
+    std::vector<BoardUndo> undoHistory;
     Result result;
-    size_t currentHash;
+    uint64_t currentHash;
     array<uint64_t, BIT_LINE_SIZE> horizontalKeys;
     array<uint64_t, BIT_LINE_SIZE> verticalKeys;
     array<uint64_t, BIT_DIAG_SIZE> upwardKeys;
@@ -33,14 +54,17 @@ PRIVATE
     MoveBucket patternBuckets[2][COMPOSITE_PATTERN_SIZE];
 
     void clearPattern(Cell& cell);
-    void setPatterns(const Pos& p);
+    void setPatterns(const Pos& p, BoardUndo* undoState = nullptr);
     void setResult(const Pos& p);
     void addPatternBucketState(const Pos& p, const Cell& cell);
     void removePatternBucketState(const Pos& p, const Cell& cell);
     Line getLine(int x, int y, Direction dir);
     Pattern getPattern(const Line& line, Color color);
     Pattern getPattern(uint32_t lineKey, Color color);
+    static Pattern calculatePattern(uint32_t lineKey, Color color, PatternCache& cache);
+    static const PatternCache& getPatternCache();
     void setBitKeys(int x, int y, Piece piece);
+    uint64_t getLineBits(int x, int y, Direction dir) const;
     uint32_t getLineKey(int x, int y, Direction dir) const;
     static int toBitCoord(int coord);
     static uint64_t makeFilledBitLine(Piece piece);
@@ -67,8 +91,8 @@ PUBLIC
     Pos getFirstPatternPos(Piece piece, CompositePattern pattern) const;
     const MoveBucket& getPatternBucket(Piece piece, CompositePattern pattern) const;
     MoveList& getPath();
-    size_t getCurrentHash() const;
-    size_t getChildHash(const Pos& p);
+    uint64_t getCurrentHash() const;
+    uint64_t getChildHash(const Pos& p);
     
 };
 
@@ -76,6 +100,7 @@ Board::Board() {
     currentHash = 0;
     result = ONGOING;
     path.reserve(BOARD_SIZE * BOARD_SIZE);
+    undoHistory.reserve(BOARD_SIZE * BOARD_SIZE);
     horizontalKeys.fill(makeFilledBitLine(WALL));
     verticalKeys.fill(makeFilledBitLine(WALL));
     upwardKeys.fill(makeFilledBitLine(WALL));
@@ -130,9 +155,18 @@ bool Board::move(const Pos& p) {
     if (result != ONGOING) return false;
     if (path.size() == BOARD_SIZE * BOARD_SIZE) return false;
 
+    const Result previousResult = result;
     path.push_back(p);
 
     setResult(p);
+
+    undoHistory.emplace_back();
+    BoardUndo& undoState = undoHistory.back();
+    undoState.previousResult = previousResult;
+    for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
+        undoState.targetBlackPatterns[dir] = targetCell.getPattern(BLACK, dir);
+        undoState.targetWhitePatterns[dir] = targetCell.getPattern(WHITE, dir);
+    }
 
     Piece piece = isBlackTurn() ? WHITE : BLACK;
     removePatternBucketState(p, targetCell);
@@ -142,7 +176,7 @@ bool Board::move(const Pos& p) {
 
     clearPattern(targetCell);
     targetCell.clearCompositePattern();
-    setPatterns(p);
+    setPatterns(p, &undoState);
 
     return true;
 }
@@ -154,8 +188,13 @@ void Board::undo() {
     // if passed
     if (p.isDefault()) {
         path.pop_back();
+        if (!undoHistory.empty()) {
+            undoHistory.pop_back();
+        }
         return;
     }
+
+    BoardUndo& undoState = undoHistory.back();
 
     Cell& targetCell = getCell(p);
     Piece piece = targetCell.getPiece();
@@ -165,8 +204,64 @@ void Board::undo() {
     setBitKeys(p.x, p.y, EMPTY);
 
     path.pop_back();
-    setPatterns(p);
-    result = ONGOING;
+
+    for (uint8_t i = 0; i < undoState.changedPatternCount; ++i) {
+        const PatternUndo& patternUndo = undoState.changedPatterns[i];
+        const Pos changedPos(patternUndo.cellCode >> 4, patternUndo.cellCode & 0x0F);
+        Cell& cell = getCell(changedPos);
+        removePatternBucketState(changedPos, cell);
+
+        Pattern blackPattern = patternUndo.blackPattern;
+        Pattern whitePattern = patternUndo.whitePattern;
+        if (blackPattern == NONE || whitePattern == NONE) {
+            const uint32_t lineKey =
+                getLineKey(changedPos.x, changedPos.y, patternUndo.direction);
+            if (blackPattern == NONE) {
+                const uint32_t blackLineKey =
+                    (lineKey & ~(0x3u << CENTER_SHIFT))
+                    | (static_cast<uint32_t>(BLACK) << CENTER_SHIFT);
+                blackPattern = getPattern(blackLineKey, COLOR_BLACK);
+            }
+            if (whitePattern == NONE) {
+                const uint32_t whiteLineKey =
+                    (lineKey & ~(0x3u << CENTER_SHIFT))
+                    | (static_cast<uint32_t>(WHITE) << CENTER_SHIFT);
+                whitePattern = getPattern(whiteLineKey, COLOR_WHITE);
+            }
+        }
+
+        cell.setPattern(BLACK, patternUndo.direction, blackPattern);
+        cell.setPattern(WHITE, patternUndo.direction, whitePattern);
+        cell.updateDerived();
+        addPatternBucketState(changedPos, cell);
+    }
+
+    for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
+        Pattern blackPattern = undoState.targetBlackPatterns[dir];
+        Pattern whitePattern = undoState.targetWhitePatterns[dir];
+        if (blackPattern == NONE || whitePattern == NONE) {
+            const uint32_t lineKey = getLineKey(p.x, p.y, dir);
+            if (blackPattern == NONE) {
+                const uint32_t blackLineKey =
+                    (lineKey & ~(0x3u << CENTER_SHIFT))
+                    | (static_cast<uint32_t>(BLACK) << CENTER_SHIFT);
+                blackPattern = getPattern(blackLineKey, COLOR_BLACK);
+            }
+            if (whitePattern == NONE) {
+                const uint32_t whiteLineKey =
+                    (lineKey & ~(0x3u << CENTER_SHIFT))
+                    | (static_cast<uint32_t>(WHITE) << CENTER_SHIFT);
+                whitePattern = getPattern(whiteLineKey, COLOR_WHITE);
+            }
+        }
+        targetCell.setPattern(BLACK, dir, blackPattern);
+        targetCell.setPattern(WHITE, dir, whitePattern);
+    }
+    targetCell.updateDerived();
+    addPatternBucketState(p, targetCell);
+
+    result = undoState.previousResult;
+    undoHistory.pop_back();
 }
 
 bool Board::pass() {
@@ -175,6 +270,7 @@ bool Board::pass() {
 
     Pos p;
     path.push_back(p);
+    undoHistory.emplace_back();
     return true;
 }
 
@@ -277,12 +373,12 @@ const MoveBucket& Board::getPatternBucket(Piece piece, CompositePattern pattern)
     return patternBuckets[piece][pattern];
 }
 
-size_t Board::getCurrentHash() const {
+uint64_t Board::getCurrentHash() const {
     return currentHash;
 }
 
-size_t Board::getChildHash(const Pos& p) {
-    size_t result = currentHash;
+uint64_t Board::getChildHash(const Pos& p) {
+    uint64_t result = currentHash;
     Piece piece = isBlackTurn() ? BLACK : WHITE;
     result ^= getZobristValue(p.x, p.y, piece);
     return result;
@@ -406,22 +502,27 @@ void Board::setBitKeys(int x, int y, Piece piece) {
     downwardKeys[bx + by] = (downwardKeys[bx + by] & ~xMask) | (value << xShift);
 }
 
-uint32_t Board::getLineKey(int x, int y, Direction dir) const {
+uint64_t Board::getLineBits(int x, int y, Direction dir) const {
     const int bx = toBitCoord(x);
     const int by = toBitCoord(y);
 
     switch (dir) {
         case HORIZONTAL:
-            return static_cast<uint32_t>((horizontalKeys[bx] >> ((by - LINE_PADDING) * 2)) & LINE_KEY_MASK);
+            return horizontalKeys[bx] >> ((by - LINE_PADDING) * 2);
         case VERTICAL:
-            return static_cast<uint32_t>((verticalKeys[by] >> ((bx - LINE_PADDING) * 2)) & LINE_KEY_MASK);
+            return verticalKeys[by] >> ((bx - LINE_PADDING) * 2);
         case UPWARD:
-            return static_cast<uint32_t>((upwardKeys[bx - by + (BIT_LINE_SIZE - 1)] >> ((bx - LINE_PADDING) * 2)) & LINE_KEY_MASK);
+            return upwardKeys[bx - by + (BIT_LINE_SIZE - 1)]
+                >> ((bx - LINE_PADDING) * 2);
         case DOWNWARD:
-            return static_cast<uint32_t>((downwardKeys[bx + by] >> ((bx - LINE_PADDING) * 2)) & LINE_KEY_MASK);
+            return downwardKeys[bx + by] >> ((bx - LINE_PADDING) * 2);
         default:
             return 0;
     }
+}
+
+uint32_t Board::getLineKey(int x, int y, Direction dir) const {
+    return static_cast<uint32_t>(getLineBits(x, y, dir) & LINE_KEY_MASK);
 }
 
 void Board::clearPattern(Cell& cell) {
@@ -431,31 +532,58 @@ void Board::clearPattern(Cell& cell) {
     }
 }
 
-void Board::setPatterns(const Pos& p) {
+void Board::setPatterns(const Pos& p, BoardUndo* undoState) {
     const int originX = p.x;
     const int originY = p.y;
 
     std::array<Pos, LINE_LENGTH * DIRECTION_SIZE> touchedCells;
     size_t touchedCount = 0;
-    std::array<std::array<bool, BOARD_SIZE + 2>, BOARD_SIZE + 2> isTouched = {};
+    bool originTouched = false;
 
     for (Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
         const int dx = getDirectionDx(dir);
         const int dy = getDirectionDy(dir);
-        for (int i = 0; i < LINE_LENGTH; i++) {
-            const int offset = i - (LINE_LENGTH / 2);
+
+        int startOffset = -LINE_PADDING;
+        int endOffset = LINE_PADDING;
+        while (!isBoardCoord(originX + (dx * startOffset), originY + (dy * startOffset))) {
+            ++startOffset;
+        }
+        while (!isBoardCoord(originX + (dx * endOffset), originY + (dy * endOffset))) {
+            --endOffset;
+        }
+
+        const int startX = originX + (dx * startOffset);
+        const int startY = originY + (dy * startOffset);
+        uint64_t slidingBits = getLineBits(startX, startY, dir);
+
+        for (int offset = startOffset; offset <= endOffset; ++offset) {
             const int x = originX + (dx * offset);
             const int y = originY + (dy * offset);
-            if (!isBoardCoord(x, y)) {
-                continue;
-            }
 
             Cell& c = getCell(x, y);
             if (c.getPiece() == EMPTY) {
-                if (!isTouched[x][y]) {
+                const bool isOrigin = offset == 0;
+                const bool firstTouch = !isOrigin || !originTouched;
+                if (firstTouch) {
                     removePatternBucketState(Pos(x, y), c);
+                    touchedCells[touchedCount++] = Pos(x, y);
+                    if (isOrigin) {
+                        originTouched = true;
+                    }
                 }
-                const uint32_t lineKey = getLineKey(x, y, dir);
+
+                if (undoState != nullptr) {
+                    PatternUndo& patternUndo =
+                        undoState->changedPatterns[undoState->changedPatternCount++];
+                    patternUndo.cellCode = static_cast<uint8_t>((x << 4) | y);
+                    patternUndo.direction = dir;
+                    patternUndo.blackPattern = c.getPattern(BLACK, dir);
+                    patternUndo.whitePattern = c.getPattern(WHITE, dir);
+                }
+
+                const uint32_t lineKey =
+                    static_cast<uint32_t>(slidingBits & LINE_KEY_MASK);
                 const uint32_t blackLineKey =
                     (lineKey & ~(0x3u << CENTER_SHIFT)) | (static_cast<uint32_t>(BLACK) << CENTER_SHIFT);
                 const uint32_t whiteLineKey =
@@ -463,12 +591,9 @@ void Board::setPatterns(const Pos& p) {
 
                 c.setPattern(BLACK, dir, getPattern(blackLineKey, COLOR_BLACK));
                 c.setPattern(WHITE, dir, getPattern(whiteLineKey, COLOR_WHITE));
-
-                if (!isTouched[x][y]) {
-                    isTouched[x][y] = true;
-                    touchedCells[touchedCount++] = Pos(x, y);
-                }
             }
+
+            slidingBits >>= 2;
         }
     }
 
@@ -508,17 +633,39 @@ Pattern Board::getPattern(const Line& line, Color color) {
 }
 
 Pattern Board::getPattern(uint32_t lineKey, Color color) {
-    constexpr uint32_t PIECE_BITS = 2;
-    constexpr uint32_t COLOR_SHIFT = LINE_LENGTH * PIECE_BITS;
-    constexpr uint32_t CACHE_SIZE = 1u << (COLOR_SHIFT + 1);
+    const uint32_t colorKey = color == COLOR_WHITE
+        ? (1u << PATTERN_CACHE_COLOR_SHIFT)
+        : 0u;
+    return static_cast<Pattern>(getPatternCache()[colorKey | lineKey] - 1);
+}
+
+const Board::PatternCache& Board::getPatternCache() {
+    static const PatternCache patternCache = []() {
+        PatternCache cache = {};
+        const uint32_t lineKeyCount = 1u << PATTERN_CACHE_COLOR_SHIFT;
+        constexpr int mid = LINE_LENGTH / 2;
+
+        for (Color color : {COLOR_BLACK, COLOR_WHITE}) {
+            const Piece self = color == COLOR_BLACK ? BLACK : WHITE;
+            for (uint32_t lineKey = 0; lineKey < lineKeyCount; ++lineKey) {
+                if (getLineKeyPiece(lineKey, mid) == self) {
+                    calculatePattern(lineKey, color, cache);
+                }
+            }
+        }
+        return cache;
+    }();
+    return patternCache;
+}
+
+Pattern Board::calculatePattern(uint32_t lineKey, Color color, PatternCache& cache) {
     constexpr uint8_t CACHE_UNSET = 0;
+    const uint32_t colorKey = color == COLOR_WHITE
+        ? (1u << PATTERN_CACHE_COLOR_SHIFT)
+        : 0u;
+    const uint32_t key = colorKey | lineKey;
 
-    static array<uint8_t, CACHE_SIZE> patternCache = {};
-
-    uint32_t key = (color == COLOR_WHITE) ? (1u << COLOR_SHIFT) : 0u;
-    key |= lineKey;
-
-    const uint8_t cachedPattern = patternCache[key];
+    const uint8_t cachedPattern = cache[key];
     if (cachedPattern != CACHE_UNSET) {
         return static_cast<Pattern>(cachedPattern - 1);
     }
@@ -531,15 +678,15 @@ Pattern Board::getPattern(uint32_t lineKey, Color color) {
     tie(realLen, fullLen, start, end) = countLineKey(lineKey);
 
     if (isBlack && realLen >= 6) {
-        patternCache[key] = static_cast<uint8_t>(OVERLINE) + 1;
+        cache[key] = static_cast<uint8_t>(OVERLINE) + 1;
         return OVERLINE;
     }
     else if (realLen >= 5) {
-        patternCache[key] = static_cast<uint8_t>(FIVE) + 1;
+        cache[key] = static_cast<uint8_t>(FIVE) + 1;
         return FIVE;
     }
     else if (fullLen < 5) {
-        patternCache[key] = static_cast<uint8_t>(DEAD) + 1;
+        cache[key] = static_cast<uint8_t>(DEAD) + 1;
         return DEAD;
     }
 
@@ -552,7 +699,7 @@ Pattern Board::getPattern(uint32_t lineKey, Color color) {
         if (piece == EMPTY) {
             uint32_t shiftedLineKey = shiftLineKey(lineKey, i);
             shiftedLineKey = setLineKeyPiece(shiftedLineKey, mid, self);
-            Pattern slp = getPattern(shiftedLineKey, color);
+            Pattern slp = calculatePattern(shiftedLineKey, color, cache);
         
             if (slp == FIVE && patternCnt[FIVE] < 2) {
                 fiveIdx[patternCnt[FIVE]] = i;
@@ -588,7 +735,7 @@ Pattern Board::getPattern(uint32_t lineKey, Color color) {
     else if (patternCnt[BLOCKED_2])
         p = BLOCKED_1;
     
-    patternCache[key] = static_cast<uint8_t>(p) + 1;
+    cache[key] = static_cast<uint8_t>(p) + 1;
     return p;
 }
 

--- a/ios/cpp/game/cell.h
+++ b/ios/cpp/game/cell.h
@@ -6,13 +6,15 @@
 
 using Score = int;
 
-// score table                            N  D   OL  B1  F1  B2  F2  F2  F2  B3  F3  F3  B4   F4     F5     UNUSED
+// score table                                N  D   OL  B1  F1  B2  F2  F2  F2  B3  F3  F3  B4   F4     F5     UNUSED
 const Score attackScore[PATTERN_SIZE + 1] = { 0, 00, 00, 01, 01, 04, 05, 06, 07, 21, 21, 20, 400, 10000, 50000, 0 };
 const Score defendScore[PATTERN_SIZE + 1] = { 0, 00, 00, 00, 00, 02, 02, 02, 02, 07, 07, 07,  90, 02000, 50000, 0 };
 
 using PatternKey = uint16_t;
 constexpr int PATTERN_KEY_BITS = 4;
 constexpr int PATTERN_KEY_SIZE = 1 << (DIRECTION_SIZE * PATTERN_KEY_BITS);
+static_assert(PATTERN_SIZE < (1 << PATTERN_KEY_BITS),
+    "Every Pattern value must fit in one packed nibble.");
 
 inline Pattern decodePatternKey(PatternKey key, int dir) {
     return static_cast<Pattern>((key >> (dir * PATTERN_KEY_BITS)) & 0xF);
@@ -125,11 +127,9 @@ class Cell {
 
 private:
     Score score[2];
-    Pattern patterns[2][DIRECTION_SIZE];
+    PatternKey patternKeys[2];
     CompositePattern cPattern[2];
     Piece piece;
-    
-    PatternKey getPatternKey(Piece piece) const;
 
 public:
     Cell();
@@ -145,13 +145,12 @@ public:
     void updateDerived();
     
 };
+static_assert(sizeof(Cell) == 16, "Cell must stay compact.");
 
 Cell::Cell() {
     this->piece = EMPTY;
-    for(Direction dir = DIRECTION_START; dir < DIRECTION_SIZE; dir++) {
-        setPattern(BLACK, dir, NONE);
-        setPattern(WHITE, dir, NONE);
-    }
+    patternKeys[BLACK] = 0;
+    patternKeys[WHITE] = 0;
     score[BLACK] = 0;
     score[WHITE] = 0;
     cPattern[BLACK] = ETC;
@@ -167,7 +166,7 @@ void Cell::setPiece(const Piece& piece) {
 }
 
 Pattern Cell::getPattern(Piece piece, Direction dir) const {
-    return patterns[piece][dir];
+    return decodePatternKey(patternKeys[piece], static_cast<int>(dir));
 }
 
 CompositePattern Cell::getCompositePattern(Piece piece) const {
@@ -179,7 +178,11 @@ Score Cell::getScore(Piece piece) const {
 }
 
 void Cell::setPattern(Piece piece, Direction dir, Pattern pattern) {
-    this->patterns[piece][dir] = pattern;
+    const int shift = static_cast<int>(dir) * PATTERN_KEY_BITS;
+    const PatternKey mask = static_cast<PatternKey>(0xFu << shift);
+    patternKeys[piece] = static_cast<PatternKey>(
+        (patternKeys[piece] & static_cast<PatternKey>(~mask))
+        | (static_cast<PatternKey>(pattern) << shift));
 }
 
 void Cell::clearCompositePattern() {
@@ -187,31 +190,23 @@ void Cell::clearCompositePattern() {
     cPattern[WHITE] = NOT_EMPTY;
 }
 
-PatternKey Cell::getPatternKey(Piece piece) const {
-    PatternKey key = 0;
-    for (int dir = 0; dir < DIRECTION_SIZE; ++dir) {
-        key |= static_cast<PatternKey>(patterns[piece][dir]) << (dir * PATTERN_KEY_BITS);
-    }
-    return key;
-}
-
 void Cell::setCompositePattern() {
-    const PatternKey blackKey = getPatternKey(BLACK);
-    const PatternKey whiteKey = getPatternKey(WHITE);
+    const PatternKey blackKey = patternKeys[BLACK];
+    const PatternKey whiteKey = patternKeys[WHITE];
     cPattern[BLACK] = blackCompositeLUT()[blackKey];
     cPattern[WHITE] = whiteCompositeLUT()[whiteKey];
 }
 
 void Cell::setScore() {
-    const PatternKey blackKey = getPatternKey(BLACK);
-    const PatternKey whiteKey = getPatternKey(WHITE);
+    const PatternKey blackKey = patternKeys[BLACK];
+    const PatternKey whiteKey = patternKeys[WHITE];
     score[BLACK] = attackScoreLUT()[blackKey] + defendScoreLUT()[whiteKey];
     score[WHITE] = attackScoreLUT()[whiteKey] + defendScoreLUT()[blackKey];
 }
 
 void Cell::updateDerived() {
-    const PatternKey blackKey = getPatternKey(BLACK);
-    const PatternKey whiteKey = getPatternKey(WHITE);
+    const PatternKey blackKey = patternKeys[BLACK];
+    const PatternKey whiteKey = patternKeys[WHITE];
     score[BLACK] = attackScoreLUT()[blackKey] + defendScoreLUT()[whiteKey];
     score[WHITE] = attackScoreLUT()[whiteKey] + defendScoreLUT()[blackKey];
     cPattern[BLACK] = blackCompositeLUT()[blackKey];

--- a/ios/cpp/game/fixed_move_list.h
+++ b/ios/cpp/game/fixed_move_list.h
@@ -75,3 +75,5 @@ public:
         return std::vector<Pos>(begin(), end());
     }
 };
+
+using CandidateList = FixedMoveList<BOARD_SIZE * BOARD_SIZE>;

--- a/ios/cpp/game/zobrist.h
+++ b/ios/cpp/game/zobrist.h
@@ -1,29 +1,29 @@
 #pragma once
 
-#include "board.h"
-#include <random>
+#include "pos.h"
+#include <cstdint>
 #include <mutex>
+#include <random>
 
 #define NUM_PIECE_TYPES 4
 
-static size_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
-static std::once_flag zobristInitFlag;
+inline constexpr uint64_t ZOBRIST_SEED = 0x9E3779B97F4A7C15ULL;
+inline uint64_t zobristTable[BOARD_SIZE + 2][BOARD_SIZE + 2][NUM_PIECE_TYPES];
+inline std::once_flag zobristInitFlag;
 
-static void initializeZobristTable() {
-    std::random_device rd;
-    std::mt19937_64 rng(rd());
-    std::uniform_int_distribution<size_t> dist(0, std::numeric_limits<size_t>::max());
+inline void initializeZobristTable() {
+    std::mt19937_64 rng(ZOBRIST_SEED);
 
     for (int i = 0; i <= BOARD_SIZE + 1; ++i) {
         for (int j = 0; j <= BOARD_SIZE + 1; ++j) {
             for (int k = 0; k < NUM_PIECE_TYPES; ++k) {
-                zobristTable[i][j][k] = dist(rng);
+                zobristTable[i][j][k] = rng();
             }
         }
     }
 }
 
-static size_t getZobristValue(int x, int y, Piece piece) {
+inline uint64_t getZobristValue(int x, int y, Piece piece) {
     std::call_once(zobristInitFlag, initializeZobristTable);
     return zobristTable[x][y][piece];
 }

--- a/ios/cpp/search/detail/core.h
+++ b/ios/cpp/search/detail/core.h
@@ -304,6 +304,25 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
         state.lastRootStats.clear();
     }
 
+    // mate-distance pruning: an ongoing position can never win faster than
+    // WIN(1) (game ends on the very next move) nor lose faster than LOSE(0).
+    // If the window already guarantees an equal-or-faster result, this subtree
+    // cannot change the outcome — return the bound before paying for TT probes,
+    // Evaluator construction, and child moves. Terminal positions are excluded:
+    // they may evaluate to WIN(0)/LOSE(0) and are handled by isGameOver below.
+    if (board.getResult() == ONGOING) {
+        Value fastestWin(Value::Result::WIN, 1);
+        if (alpha >= fastestWin) {
+            fastestWin.setType(Value::Type::UPPER_BOUND);
+            return fastestWin;
+        }
+        Value fastestLose(Value::Result::LOSE, 0);
+        if (beta <= fastestLose) {
+            fastestLose.setType(Value::Type::LOWER_BOUND);
+            return fastestLose;
+        }
+    }
+
     const Value originalAlpha = alpha;
     const Value originalBeta = beta;
 

--- a/ios/cpp/search/detail/core.h
+++ b/ios/cpp/search/detail/core.h
@@ -131,8 +131,9 @@ Search::ChildSearchResult Search::searchChildPVS(int depth, bool isMax, size_t m
     nextBestVal.decreaseResultDepth();
 
     if (moveIndex == 0) {
-        result.value = abp(depth - 1, !isMax, nextAlpha, nextBeta, &result.pv);
-        result.hasExactPV = result.value.getType() == Value::Type::EXACT;
+        MoveList* childPV = pv != nullptr ? &result.pv : nullptr;
+        result.value = abp(depth - 1, !isMax, nextAlpha, nextBeta, childPV);
+        result.hasExactPV = childPV != nullptr && result.value.getType() == Value::Type::EXACT;
         return result;
     }
 
@@ -237,7 +238,8 @@ Value Search::finalizeNodeValue(bool isMax, Value originalAlpha, Value originalB
     return result;
 }
 
-void Search::updateHistoryFromNode(int depth, const Pos& bestMove, const MoveList& searchedMoves,
+void Search::updateHistoryFromNode(int depth, const Pos& bestMove,
+    const uint8_t* searchedMoveCodes, size_t searchedMoveCount,
     bool causedCutoff, Value result, bool sideToMoveIsBlack) {
     if (!searchActive() || bestMove.isDefault()) {
         return;
@@ -246,9 +248,18 @@ void Search::updateHistoryFromNode(int depth, const Pos& bestMove, const MoveLis
     const int bonus = std::max(1, std::min(depth * depth, 256));
     if (causedCutoff || result.getType() == Value::Type::LOWER_BOUND) {
         updateHistoryScore(bestMove, sideToMoveIsBlack, bonus);
+        // killer slots only remember cutoff moves that make at least a four for the
+        // mover: those transfer to sibling nodes, while quiet cutoff moves would just
+        // displace the static block-the-biggest-threat order and grow the tree
+        if (board.getCell(bestMove).getScore(sideToMoveIsBlack ? BLACK : WHITE)
+            >= KILLER_MIN_FOUR_SCORE) {
+            updateKillerMove(getSearchPly(), packMoveCode(bestMove));
+        }
 
         const int penalty = std::max(1, bonus / 2);
-        for (const Pos& move : searchedMoves) {
+        for (size_t i = 0; i < searchedMoveCount; ++i) {
+            const uint8_t code = searchedMoveCodes[i];
+            const Pos move(code >> 4, code & 0x0F);
             if (!(move == bestMove)) {
                 updateHistoryScore(move, sideToMoveIsBlack, -penalty);
             }
@@ -326,7 +337,7 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
     // applying it in DEFENSIVE mode would invent false LOSE/WIN at quiet positions.
     const bool threatBrokenLeaf = options.mode == Mode::VCT
         && !attackerTurn && !evaluator.isOppoMateExist();
-    MoveList moves = getCandidates(evaluator, isMax);
+    CandidateList moves = getCandidates(evaluator, isMax);
     if (moves.empty()) {
         return threatBrokenLeaf
             ? evaluateThreatBrokenLeaf(isMax, depth)
@@ -342,8 +353,8 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
         : Value(MAX_VALUE + 1, Value::Type::UNKNOWN);
     Pos bestMove;
     MoveList bestChildPV;
-    MoveList searchedMoves;
-    searchedMoves.reserve(moves.size());
+    uint8_t searchedMoveCodes[BOARD_SIZE * BOARD_SIZE];
+    size_t searchedMoveCount = 0;
 
     const int shallowMoveLimit = getShallowMoveLimit(evaluator, depth, attackerTurn);
     const bool sideToMoveIsBlack = board.isBlackTurn();
@@ -366,7 +377,8 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
         tt.prefetch(getTTKey(board));
 
         searchedAny = true;
-        searchedMoves.push_back(move);
+        searchedMoveCodes[searchedMoveCount++] =
+            static_cast<uint8_t>((move.getX() << 4) | move.getY());
         recordNodeVisit();
         const size_t nodeCountBeforeMove = isRootNode ? monitor.getVisitCnt() : 0;
         const double elapsedBeforeMove = isRootNode ? monitor.getElapsedTime() : 0.0;
@@ -409,7 +421,8 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
     }
 
     Value result = finalizeNodeValue(isMax, originalAlpha, originalBeta, alpha, beta, bestVal);
-    updateHistoryFromNode(depth, bestMove, searchedMoves, causedCutoff, result, sideToMoveIsBlack);
+    updateHistoryFromNode(depth, bestMove, searchedMoveCodes, searchedMoveCount,
+        causedCutoff, result, sideToMoveIsBlack);
 
     if (searchActive()) {
         storeTT(board, result, depth, bestMove);
@@ -423,8 +436,8 @@ Value Search::evaluateNode(Evaluator& evaluator) {
     return evaluator.evaluateTactical();
 }
 
-MoveList Search::getCandidates(Evaluator& evaluator, bool isMax) {
-    MoveList moves;
+CandidateList Search::getCandidates(Evaluator& evaluator, bool isMax) {
+    CandidateList moves;
 
     Pos sureMove = evaluator.getSureMove();
     if (!sureMove.isDefault()) {
@@ -438,21 +451,24 @@ MoveList Search::getCandidates(Evaluator& evaluator, bool isMax) {
         const bool atRoot = (board.getPath().size() == rootBoard.getPath().size());
 
         if (evaluator.isOppoMateExist()) {
-            moves = evaluator.getThreatDefend();
-            MoveList fours = evaluator.getFours();
-            moves.insert(moves.end(), fours.begin(), fours.end());
+            evaluator.getThreatDefend(moves);
+            CandidateList fours;
+            evaluator.getFours(fours);
+            appendUniqueMoves(moves, fours);
         } else if (evaluator.isOppoFourThreeExist()) {
-            moves = evaluator.getFourThreeDefend();
-            MoveList fours = evaluator.getFours();
-            moves.insert(moves.end(), fours.begin(), fours.end());
+            evaluator.getFourThreeDefend(moves);
+            CandidateList fours;
+            evaluator.getFours(fours);
+            appendUniqueMoves(moves, fours);
         } else {
             if (atRoot) {
-                moves = evaluator.getCandidates();
+                evaluator.getCandidates(moves);
                 return moves;
             }
-            moves = evaluator.getThreats();
-            MoveList makers = evaluator.getFourThreeMakers();
-            moves.insert(moves.end(), makers.begin(), makers.end());
+            evaluator.getThreats(moves);
+            CandidateList makers;
+            evaluator.getFourThreeMakers(makers);
+            appendUniqueMoves(moves, makers);
         }
         return moves;
     }
@@ -460,42 +476,64 @@ MoveList Search::getCandidates(Evaluator& evaluator, bool isMax) {
     if (options.mode == Mode::VCT) {
         const bool attackerTurn = (board.isBlackTurn() == rootBoard.isBlackTurn());
         if (attackerTurn) {
-            moves = evaluator.getThreats();
-            MoveList makers = evaluator.getFourThreeMakers();
-            moves.insert(moves.end(), makers.begin(), makers.end());
+            evaluator.getThreats(moves);
+            CandidateList makers;
+            evaluator.getFourThreeMakers(makers);
+            appendUniqueMoves(moves, makers);
         } else if (evaluator.isOppoMateExist()) {
-            moves = evaluator.getThreatDefend();
-            MoveList fours = evaluator.getFours();
-            moves.insert(moves.end(), fours.begin(), fours.end());
+            evaluator.getThreatDefend(moves);
+            CandidateList fours;
+            evaluator.getFours(fours);
+            appendUniqueMoves(moves, fours);
         } else if (evaluator.isOppoFourThreeExist()) {
-            moves = evaluator.getFourThreeDefend();
-            MoveList fours = evaluator.getFours();
-            moves.insert(moves.end(), fours.begin(), fours.end());
+            evaluator.getFourThreeDefend(moves);
+            CandidateList fours;
+            evaluator.getFours(fours);
+            appendUniqueMoves(moves, fours);
         }
     }
 
     return moves;
 }
 
-void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
+void Search::appendUniqueMoves(CandidateList& moves, const CandidateList& extraMoves) const {
+    if (extraMoves.empty()) {
+        return;
+    }
+
+    moves.reserve(moves.size() + extraMoves.size());
+    for (const Pos& move : extraMoves) {
+        if (std::find(moves.begin(), moves.end(), move) == moves.end()) {
+            moves.push_back(move);
+        }
+    }
+}
+
+void Search::sortChildNodes(CandidateList& moves, bool isMax, const TTEntry* entry) {
     if (moves.size() < 2) {
         return;
     }
 
     struct MoveOrderInfo {
-        Pos move;
+        uint8_t moveCode;
         bool isTTBest;
         bool hasTT;
         int flagPriority;
         int32_t ttScore;
         int historyScore;
         int cellScore;
+        int killerRank;
     };
 
     const Pos ttBestMove = (entry != nullptr && entry->bestMove != TranspositionTable::INVALID_MOVE)
         ? TranspositionTable::decodeMove(entry->bestMove)
         : Pos();
     const bool sideToMoveIsBlack = board.isBlackTurn();
+    const size_t searchPly = getSearchPly();
+    const uint8_t killerCode0 =
+        searchPly < state.killerMoves.size() ? state.killerMoves[searchPly][0] : 0;
+    const uint8_t killerCode1 =
+        searchPly < state.killerMoves.size() ? state.killerMoves[searchPly][1] : 0;
     bool hasHistorySignal = false;
 
     for (const Pos& move : moves) {
@@ -524,8 +562,8 @@ void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
         return 2;
     };
 
-    vector<MoveOrderInfo> infos;
-    infos.reserve(moves.size());
+    MoveOrderInfo infos[BOARD_SIZE * BOARD_SIZE];
+    size_t infoCount = 0;
 
     // Attacker (isMax) prefers self-attack score; defender wants to block opponent's most
     // threatening spot, so uses opponent's score. Matches the evaluator's previous sort intent.
@@ -545,17 +583,25 @@ void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
                 ? &childEntryStorage
                 : nullptr;
         MoveOrderInfo info;
-        info.move = move;
+        info.moveCode = static_cast<uint8_t>((move.getX() << 4) | move.getY());
         info.isTTBest = !ttBestMove.isDefault() && move == ttBestMove;
         info.hasTT = childEntry != nullptr;
         info.flagPriority = childEntry != nullptr ? getValueTypePriority(childEntry->getFlag()) : getValueTypePriority(TTFlag::NONE);
         info.ttScore = childEntry != nullptr ? childEntry->score : 0;
         info.historyScore = getHistoryScore(move, sideToMoveIsBlack);
         info.cellScore = board.getCell(move).getScore(scorePiece);
-        infos.push_back(info);
+        info.killerRank = 0;
+        if (info.moveCode == killerCode0 || info.moveCode == killerCode1) {
+            // stored killers made a four where they cut off; re-validate on this
+            // board since the same cell may no longer make one here
+            if (board.getCell(move).getScore(sideToMovePiece) >= KILLER_MIN_FOUR_SCORE) {
+                info.killerRank = info.moveCode == killerCode0 ? 2 : 1;
+            }
+        }
+        infos[infoCount++] = info;
     }
 
-    std::stable_sort(infos.begin(), infos.end(), [&](const MoveOrderInfo& a, const MoveOrderInfo& b) {
+    std::stable_sort(infos, infos + infoCount, [&](const MoveOrderInfo& a, const MoveOrderInfo& b) {
         if (a.isTTBest != b.isTTBest) {
             return a.isTTBest;
         }
@@ -572,6 +618,11 @@ void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
         if (a.flagPriority != b.flagPriority) {
             return a.flagPriority < b.flagPriority;
         }
+        // recent four-making cutoff moves outrank the static cell score: they either
+        // refute the line the same way they refuted a sibling, or fail fast (forcing)
+        if (a.killerRank != b.killerRank) {
+            return a.killerRank > b.killerRank;
+        }
         if (a.cellScore != b.cellScore) {
             return a.cellScore > b.cellScore;
         }
@@ -582,7 +633,8 @@ void Search::sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry) {
     });
 
     for (size_t i = 0; i < moves.size(); ++i) {
-        moves[i] = infos[i].move;
+        const uint8_t code = infos[i].moveCode;
+        moves[i] = Pos(code >> 4, code & 0x0F);
     }
 }
 

--- a/ios/cpp/search/detail/core.h
+++ b/ios/cpp/search/detail/core.h
@@ -9,13 +9,20 @@ bool Search::tryResolveFromTT(int depth, Value& alpha, Value& beta, MoveList* pv
         return false;
     }
 
+    // root: keep ttEntry for move ordering only — never resolve or tighten the
+    // window from it. The root's own stale bound (e.g. an UPPER_BOUND left by a
+    // failed aspiration window) can shrink beta enough that the first move causes
+    // a cutoff, leaving lastRootStats partial and the PV rebuilt from stale TT
+    // breadcrumbs instead of a verified line.
+    const bool isRootNode = board.getPath().size() == rootBoard.getPath().size();
+    if (isRootNode) {
+        return false;
+    }
+
     Value ttValue = getTTValue(*ttEntry);
     const TTFlag ttFlag = ttEntry->getFlag();
-    const bool isRootNode = board.getPath().size() == rootBoard.getPath().size();
-    const bool allowTerminalExactDepthBypass = !isRootNode;
 
-    if (allowTerminalExactDepthBypass &&
-        ttFlag == TTFlag::EXACT &&
+    if (ttFlag == TTFlag::EXACT &&
         (ttValue.isWin() || ttValue.isLose())) {
         if (pv != nullptr) {
             appendTTPV(board, *pv);
@@ -302,6 +309,7 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
     const bool isRootNode = board.getPath().size() == rootBoard.getPath().size();
     if (isRootNode) {
         state.lastRootStats.clear();
+        state.lastRootSearchComplete = false;
     }
 
     // mate-distance pruning: an ongoing position can never win faster than
@@ -383,9 +391,11 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
 
     bool searchedAny = false;
     bool causedCutoff = false;
+    bool searchedAll = true;
 
     for (size_t i = 0; i < moves.size(); ++i) {
         if (static_cast<int>(i) >= shallowMoveLimit) {
+            searchedAll = false;
             break;
         }
 
@@ -407,6 +417,7 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
 
         board.undo();
         if (!searchActive()) {
+            searchedAll = false;
             break;
         }
 
@@ -431,8 +442,13 @@ Value Search::abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv) 
 
         if (moveCausedCutoff) {
             causedCutoff = true;
+            searchedAll = false;
             break;
         }
+    }
+
+    if (isRootNode) {
+        state.lastRootSearchComplete = searchedAny && searchedAll;
     }
 
     if (!searchedAny) {

--- a/ios/cpp/search/detail/history.h
+++ b/ios/cpp/search/detail/history.h
@@ -27,4 +27,27 @@ void Search::clearHistory() {
     for (auto& sideHistory : state.historyScores) {
         sideHistory.fill(0);
     }
+    for (auto& killers : state.killerMoves) {
+        killers.fill(0);
+    }
+}
+
+size_t Search::getSearchPly() {
+    return board.getPath().size() - rootBoard.getPath().size();
+}
+
+uint8_t Search::packMoveCode(const Pos& move) {
+    return static_cast<uint8_t>((move.getX() << 4) | move.getY());
+}
+
+void Search::updateKillerMove(size_t ply, uint8_t moveCode) {
+    if (ply >= state.killerMoves.size() || moveCode == 0) {
+        return;
+    }
+
+    auto& killers = state.killerMoves[ply];
+    if (killers[0] != moveCode) {
+        killers[1] = killers[0];
+        killers[0] = moveCode;
+    }
 }

--- a/ios/cpp/search/detail/lifecycle.h
+++ b/ios/cpp/search/detail/lifecycle.h
@@ -137,7 +137,8 @@ size_t Search::getEstimatedMemoryBytes() const {
     return tt.getMemoryBytes()
         + (sizeof(Board) * 2)
         + (state.bestPath.capacity() * sizeof(Pos))
-        + sizeof(state.historyScores);
+        + sizeof(state.historyScores)
+        + sizeof(state.killerMoves);
 }
 
 const std::vector<Search::RootMoveStat>& Search::getLastRootStats() const {

--- a/ios/cpp/search/detail/lifecycle.h
+++ b/ios/cpp/search/detail/lifecycle.h
@@ -4,6 +4,7 @@ void Search::ids() {
     state.isRunning = true;
     state.bestPath.clear();
     state.bestValue = Value();
+    state.lastRootSearchComplete = false;
     state.nodesSinceMonitorPoll = 0;
     state.qvcfDisabledAfterWin = false;
     clearHistory();
@@ -37,8 +38,10 @@ void Search::ids() {
         }
 
         // DEFENSIVE elimination: if exactly one root candidate is non-LOSE,
-        // the answer is decided regardless of further deepening.
-        if (options.mode == Mode::DEFENSIVE) {
+        // the answer is decided regardless of further deepening. Only valid when
+        // the last root call actually searched every candidate — a partial
+        // lastRootStats (root cutoff/stop) says nothing about unsearched moves.
+        if (options.mode == Mode::DEFENSIVE && state.lastRootSearchComplete) {
             int nonLoseCount = 0;
             for (auto& stat : state.lastRootStats) {
                 if (!stat.value.isLose()) {

--- a/ios/cpp/search/detail/qvcf.h
+++ b/ios/cpp/search/detail/qvcf.h
@@ -33,7 +33,7 @@ bool Search::enterQVCFNode(QVCFContext& context) {
     return true;
 }
 
-void Search::moveQVCFTTBestFirst(MoveList& moves, const Pos& bestMove) const {
+void Search::moveQVCFTTBestFirst(CandidateList& moves, const Pos& bestMove) const {
     if (bestMove.isDefault()) {
         return;
     }
@@ -197,7 +197,8 @@ Value Search::qvcfAttack(int remainingPly, QVCFContext& context, MoveList* pv) {
         return Value();
     }
 
-    MoveList moves = evaluator.getFours();
+    CandidateList moves;
+    evaluator.getFours(moves);
     moveQVCFTTBestFirst(moves, cachedBestMove);
     if (moves.empty()) {
         storeQVCFFail(board, remainingPly);

--- a/ios/cpp/search/search.h
+++ b/ios/cpp/search/search.h
@@ -62,6 +62,8 @@ PRIVATE
         Value bestValue;
         std::vector<RootMoveStat> lastRootStats;
         std::array<std::array<int, BOARD_SIZE * BOARD_SIZE>, 2> historyScores = {};
+        // two killer slots per ply from root; entries are packed (x<<4)|y codes, 0 = empty
+        std::array<std::array<uint8_t, 2>, BOARD_SIZE * BOARD_SIZE + 4> killerMoves = {};
         size_t nodesSinceMonitorPoll = 0;
     };
 
@@ -83,13 +85,17 @@ PRIVATE
     static constexpr uint64_t QVCF_TT_KEY = 0x6a09e667f3bcc909ULL;
     static constexpr int QVCF_HEURISTIC_WIN_SCORE = MAX_VALUE - (BOARD_SIZE * BOARD_SIZE) - 1024;
     static constexpr int HISTORY_ABS_LIMIT = 16384;
+    // attackScore[B4] — a killer must make at least a four (for the mover) to be
+    // stored and to outrank the static cell score during move ordering
+    static constexpr int KILLER_MIN_FOUR_SCORE = 400;
     static constexpr int ASPIRATION_START_DELTA = 32;
     Value abp(int depth, bool isMax, Value alpha, Value beta, MoveList* pv = nullptr);
     Value searchRootWithAspiration(int depth, MoveList* pv);
     Value evaluateNode(Evaluator& evaluator);
     bool searchActive() const;
-    MoveList getCandidates(Evaluator& evaluator, bool isMax);
-    void sortChildNodes(MoveList& moves, bool isMax, const TTEntry* entry);
+    CandidateList getCandidates(Evaluator& evaluator, bool isMax);
+    void appendUniqueMoves(CandidateList& moves, const CandidateList& extraMoves) const;
+    void sortChildNodes(CandidateList& moves, bool isMax, const TTEntry* entry);
     bool isGameOver(Board& board);
     uint64_t getTTKey(Board& board) const;
     uint64_t getChildTTKey(const Pos& move);
@@ -106,6 +112,9 @@ PRIVATE
     int getHistoryScore(const Pos& move, bool isBlackTurn) const;
     void updateHistoryScore(const Pos& move, bool isBlackTurn, int delta);
     void clearHistory();
+    size_t getSearchPly();
+    static uint8_t packMoveCode(const Pos& move);
+    void updateKillerMove(size_t ply, uint8_t moveCode);
     bool tryResolveFromTT(int depth, Value& alpha, Value& beta, MoveList* pv,
         TTEntry& ttEntryStorage, const TTEntry*& ttEntry, Value& resolvedValue);
     int getShallowMoveLimit(Evaluator& evaluator, int depth, bool attackerTurn);
@@ -121,7 +130,8 @@ PRIVATE
         size_t nodeCountBeforeMove, double elapsedBeforeMove, const Pos& ttBestMove);
     Value finalizeNodeValue(bool isMax, Value originalAlpha, Value originalBeta,
         Value alpha, Value beta, Value bestVal) const;
-    void updateHistoryFromNode(int depth, const Pos& bestMove, const MoveList& searchedMoves,
+    void updateHistoryFromNode(int depth, const Pos& bestMove,
+        const uint8_t* searchedMoveCodes, size_t searchedMoveCount,
         bool causedCutoff, Value result, bool sideToMoveIsBlack);
     void rebuildPV(const Pos& bestMove, const MoveList& bestChildPV, Value result, MoveList* pv) const;
     void completeWinPV(Value value, MoveList& pv);
@@ -129,7 +139,7 @@ PRIVATE
     Result getRootWinResult();
     uint64_t getQVCFTTKey(Board& targetBoard) const;
     bool enterQVCFNode(QVCFContext& context);
-    void moveQVCFTTBestFirst(MoveList& moves, const Pos& bestMove) const;
+    void moveQVCFTTBestFirst(CandidateList& moves, const Pos& bestMove) const;
     bool probeQVCFTT(Board& targetBoard, int remainingPly, Value& value, Pos& bestMove) const;
     void storeQVCFWin(Board& targetBoard, Value value, int remainingPly, const Pos& bestMove);
     void storeQVCFFail(Board& targetBoard, int remainingPly);

--- a/ios/cpp/search/search.h
+++ b/ios/cpp/search/search.h
@@ -61,6 +61,9 @@ PRIVATE
         MoveList bestPath;
         Value bestValue;
         std::vector<RootMoveStat> lastRootStats;
+        // true only when the last root abp call searched every root candidate
+        // (no cutoff, no truncation, not stopped) — lastRootStats covers all moves
+        bool lastRootSearchComplete = false;
         std::array<std::array<int, BOARD_SIZE * BOARD_SIZE>, 2> historyScores = {};
         // two killer slots per ply from root; entries are packed (x<<4)|y codes, 0 = empty
         std::array<std::array<uint8_t, 2>, BOARD_SIZE * BOARD_SIZE + 4> killerMoves = {};

--- a/ios/cpp/search/search_win.h
+++ b/ios/cpp/search/search_win.h
@@ -26,7 +26,7 @@ PRIVATE
     bool isTargetTurn();
     uint64_t getTTKey();
     uint8_t getDepthLeft();
-    void moveTTBestFirst(MoveList& moves, const TTEntry* entry);
+    void moveTTBestFirst(CandidateList& moves, const TTEntry* entry);
 
 PUBLIC
     SearchWin(Board& board, SearchMonitor& monitor);
@@ -71,7 +71,12 @@ bool SearchWin::dfsVCF() {
     monitor.incVisitCnt();
 
     Evaluator evaluator(board);
-    MoveList moves = isTargetTurn() ? evaluator.getFours() : evaluator.getCandidates();
+    CandidateList moves;
+    if (isTargetTurn()) {
+        evaluator.getFours(moves);
+    } else {
+        evaluator.getCandidates(moves);
+    }
     moveTTBestFirst(moves, probed);
 
     for (const auto& move : moves) {
@@ -144,7 +149,7 @@ uint8_t SearchWin::getDepthLeft() {
     return static_cast<uint8_t>(remain);
 }
 
-void SearchWin::moveTTBestFirst(MoveList& moves, const TTEntry* entry) {
+void SearchWin::moveTTBestFirst(CandidateList& moves, const TTEntry* entry) {
     if (entry == nullptr) return;
     if (entry->bestMove == TranspositionTable::INVALID_MOVE) return;
 

--- a/ios/cpp/search/vcf_candidate_finder.h
+++ b/ios/cpp/search/vcf_candidate_finder.h
@@ -59,7 +59,7 @@ PRIVATE
     static double getElapsedSeconds(const VCFProbeContext& context);
     static bool isWin(Board& board, VCFProbeContext& context);
     static uint64_t getVCFTTKey(Board& board);
-    static void moveTTBestFirst(MoveList& moves, const TTEntry* entry);
+    static void moveTTBestFirst(CandidateList& moves, const TTEntry* entry);
     bool shouldStopProbe(VCFProbeContext& context) const;
     bool dfsVCF(Board& board, VCFProbeContext& context);
     bool probeRootVCF(Board& probeBoard, VCFCandidateProbeResult* probeResult);
@@ -155,7 +155,7 @@ uint64_t VCFCandidateFinder::getVCFTTKey(Board& board) {
     return key;
 }
 
-void VCFCandidateFinder::moveTTBestFirst(MoveList& moves, const TTEntry* entry) {
+void VCFCandidateFinder::moveTTBestFirst(CandidateList& moves, const TTEntry* entry) {
     if (entry == nullptr) return;
     if (entry->bestMove == TranspositionTable::INVALID_MOVE) return;
 
@@ -212,9 +212,12 @@ bool VCFCandidateFinder::dfsVCF(Board& board, VCFProbeContext& context) {
     }
 
     Evaluator evaluator(board);
-    MoveList moves = isTargetTurn(board, context.targetColor)
-        ? evaluator.getFours()
-        : evaluator.getCandidates();
+    CandidateList moves;
+    if (isTargetTurn(board, context.targetColor)) {
+        evaluator.getFours(moves);
+    } else {
+        evaluator.getCandidates(moves);
+    }
     moveTTBestFirst(moves, ttEntry);
 
     for (const Pos& nextMove : moves) {
@@ -335,7 +338,9 @@ MoveList VCFCandidateFinder::findFromCandidates(const MoveList& candidates) {
 MoveList VCFCandidateFinder::findFromEvaluatorCandidates() {
     Board board(rootBoard);
     Evaluator evaluator(board);
-    return findFromCandidates(evaluator.getCandidates());
+    CandidateList candidates;
+    evaluator.getCandidates(candidates);
+    return findFromCandidates(candidates.toMoveList());
 }
 
 MoveList VCFCandidateFinder::findFromAllLegalMoves() {

--- a/src/screens/CommunityPuzzleSolve/index.styles.tsx
+++ b/src/screens/CommunityPuzzleSolve/index.styles.tsx
@@ -13,6 +13,8 @@ export const HeaderWrapper = styled(View)`
   position: absolute;
   top: 0;
   left: 0;
+  /* BoardWrapper(flex: 1)가 화면 전체를 덮으므로, 헤더가 터치를 받으려면 z-index가 필요함 */
+  z-index: 1;
 `;
 
 export const DescriptionWrapper = styled(View)`

--- a/src/screens/CommunityPuzzleSolve/index.tsx
+++ b/src/screens/CommunityPuzzleSolve/index.tsx
@@ -11,7 +11,7 @@ import {
 import PuzzleHeader from '../../components/features/PuzzleHeader';
 import { CustomModal, CustomText } from '../../components/common';
 import PuzzleStats from '../../components/features/PuzzleStats';
-import Board from '../../components/features/Board';
+import Board, { BoardRef } from '../../components/features/Board';
 import LikeDislikeToggle from '../../components/features/LikeDislikeToggle';
 import { showBottomToast } from '../../components/common/Toast/toastMessage';
 import {
@@ -59,6 +59,7 @@ const CommunityPuzzleSolve = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [boardKey, setBoardKey] = useState(0);
   const puzzleDetailRef = useRef(puzzleDetail);
+  const boardRef = useRef<BoardRef>(null);
 
   const isPuzzleResultModal =
     modalCategory === 'COMMUNITY_PUZZLE_SUCCESS' || modalCategory === 'COMMUNITY_PUZZLE_FAILURE';
@@ -158,6 +159,7 @@ const CommunityPuzzleSolve = () => {
   };
 
   const handleRetry = () => {
+    boardRef.current?.cancelAiTurn();
     if (puzzleDetail) {
       setCurrentSequence(puzzleDetail.boardStatus);
     }
@@ -196,7 +198,7 @@ const CommunityPuzzleSolve = () => {
   };
 
   const handleShowAnswer = () => {
-    if (isLoading || !puzzleDetail?.id) {
+    if (!puzzleDetail?.id) {
       return;
     }
 
@@ -208,6 +210,7 @@ const CommunityPuzzleSolve = () => {
         markSolved();
 
         await updateUser();
+        boardRef.current?.cancelAiTurn();
         showBottomToast('success', t('toast.purchaseComplete'));
         handleViewAnswerPress(data.answer);
       } catch (error) {
@@ -336,11 +339,11 @@ const CommunityPuzzleSolve = () => {
         </BoardStatsWrapper>
         <Board
           key={boardKey}
+          ref={boardRef}
           mode="solve"
           sequence={puzzleDetail.boardStatus}
           setSequence={setCurrentSequence}
           setIsWin={handleResult}
-          setIsLoading={setIsLoading}
           puzzleCache={{ puzzleType: 'COMMUNITY', puzzleId: puzzleDetail.id }}
         />
         <BoardReactionWrapper>

--- a/src/screens/PuzzleReview/index.styles.tsx
+++ b/src/screens/PuzzleReview/index.styles.tsx
@@ -18,6 +18,8 @@ export const HeaderWrapper = styled(View)`
   flex-direction: row;
   justify-content: space-between;
   align-items: start;
+  /* 뒤에 렌더되는 형제 뷰가 헤더 영역을 덮지 않도록 터치 우선순위 확보 */
+  z-index: 1;
 `;
 
 export const ButtonWrapper = styled(View)`

--- a/src/screens/TrainingPuzzleSolve/index.styles.tsx
+++ b/src/screens/TrainingPuzzleSolve/index.styles.tsx
@@ -15,6 +15,8 @@ export const HeaderWrapper = styled(View)`
   position: absolute;
   top: 0;
   left: 0;
+  /* BoardWrapper(flex: 1)가 화면 전체를 덮으므로, 헤더가 터치를 받으려면 z-index가 필요함 */
+  z-index: 1;
 `;
 
 export const BoardWrapper = styled(View)`

--- a/src/screens/TrainingPuzzleSolve/index.tsx
+++ b/src/screens/TrainingPuzzleSolve/index.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { BoardWrapper, Container, HeaderWrapper } from './index.styles';
 import PuzzleHeader from '../../components/features/PuzzleHeader';
-import Board from '../../components/features/Board';
+import Board, { BoardRef } from '../../components/features/Board';
 import { ParamListBase, RouteProp, useNavigation, useRoute } from '@react-navigation/native';
 import {
   GameOutcome,
@@ -70,6 +70,7 @@ const TrainingPuzzleSolve = () => {
   const { showAdIfReady } = usePuzzleAd();
 
   const updatedItemsRef = useRef<Map<number, TrainingPuzzle>>(new Map());
+  const boardRef = useRef<BoardRef>(null);
 
   const handleNextPuzzle = () => {
     if (puzzles.length <= currentPuzzleNumber) {
@@ -134,6 +135,7 @@ const TrainingPuzzleSolve = () => {
   };
 
   const handleRetry = () => {
+    boardRef.current?.cancelAiTurn();
     if (puzzleDetail) {
       setCurrentSequence(puzzleDetail.boardStatus);
     }
@@ -153,6 +155,7 @@ const TrainingPuzzleSolve = () => {
         markSolved(puzzleDetail);
 
         await updateUser();
+        boardRef.current?.cancelAiTurn();
         showBottomToast('success', t('toast.purchaseComplete'));
         handleViewAnswerPress(data.answer);
       } catch (error) {
@@ -269,11 +272,11 @@ const TrainingPuzzleSolve = () => {
       <BoardWrapper>
         <Board
           key={boardKey}
+          ref={boardRef}
           mode="solve"
           sequence={puzzleDetail.boardStatus}
           setSequence={setCurrentSequence}
           setIsWin={handleResult}
-          setIsLoading={() => {}}
           puzzleCache={{ puzzleType: 'TRAINING', puzzleId: puzzleDetail.id }}
         />
       </BoardWrapper>


### PR DESCRIPTION
## AI 엔진 변경 사항 적용
- killer move 추적 및 move ordering에 적용
- 가벼운 optimization

## 퍼즐 헤더 버튼 터치 불가 수정

### 문제
- 풀이 화면(커뮤니티/트레이닝)의 **새로하기·정답보기 버튼이 눌리지 않음**
- AI 계산 중에만 발생하는 것처럼 보였으나, 실제로는 항상 눌리지 않는 상태였음

### 원인
- `HeaderWrapper`가 `position: absolute`라 레이아웃 흐름에서 제외되고,
  뒤에 렌더되는 `BoardWrapper(flex: 1)`가 헤더 영역까지 화면 전체를 차지
- RN 히트테스트는 나중에 렌더된 형제가 우선이므로 헤더 터치가 전부 (투명한) BoardWrapper에 흡수됨

### 해결
- `HeaderWrapper`에 `z-index: 1` 추가 → 터치 우선순위 확보, 시각적 변화 없음
  (CommunityPuzzleSolve · TrainingPuzzleSolve · PuzzleReview 동일 패턴 일괄 적용)
- **새로하기**: `BoardRef.cancelAiTurn()` 연결 → 진행 중인 엔진 탐색 즉시 취소 후 리셋
- **정답보기**: AI 계산 중에도 구매 모달 오픈 가능하도록 `isLoading` 가드 제거,
  모달 뒤에서 엔진은 계속 계산 → 구매 성공 시에만 취소 (실패 시 게임 정상 지속)
- 화면 `isLoading`을 AI 턴 상태와 분리 → 엔진 대기 중에도 모달 버튼 활성화 유지
