### PR TITLE
Feature/change password

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -39,6 +39,7 @@ import useNetworkStore from './src/store/useNetworkStore.ts';
 import { CustomModal } from './src/components/common/index.ts';
 import Language from './src/screens/Settings/Language/index.tsx';
 import ChangeNickname from './src/screens/Settings/ChangeNickname/index.tsx';
+import ChangePassword from './src/screens/Settings/ChangePassword/index.tsx';
 
 const Stack = createNativeStackNavigator();
 
@@ -108,6 +109,11 @@ function App(): React.JSX.Element | null {
                     name="ChangeNickname"
                     component={ChangeNickname}
                     options={{ title: 'settings.changeNickname' }}
+                  />
+                  <Stack.Screen
+                    name="ChangePassword"
+                    component={ChangePassword}
+                    options={{ title: 'settings.changePassword' }}
                   />
                   <Stack.Screen
                     name="TrainingPacks"

--- a/App.tsx
+++ b/App.tsx
@@ -20,6 +20,7 @@ import Toast from 'react-native-toast-message';
 import { toastConfig } from './src/components/common/Toast/toast.config.tsx';
 import Signup from './src/screens/Signup/index.tsx';
 import Signin from './src/screens/Signin';
+import FindPassword from './src/screens/FindPassword/index.tsx';
 import Home from './src/screens/Home/index.tsx';
 import MyPuzzles from './src/screens/MyPuzzles/index.tsx';
 import LikedPuzzles from './src/screens/LikedPuzzles/index.tsx';
@@ -183,6 +184,11 @@ function App(): React.JSX.Element | null {
                     name="Signup"
                     component={Signup}
                     options={{ title: 'auth.signup' }}
+                  />
+                  <Stack.Screen
+                    name="FindPassword"
+                    component={FindPassword}
+                    options={{ title: 'auth.findPassword' }}
                   />
                 </>
               )}

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -54,6 +54,34 @@ export const registerUser = async (
   }
 };
 
+export const sendPasswordResetCode = async (email: string) => {
+  try {
+    const response = await apiClient.post('/api/auth/password/reset/email', { email });
+
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const resetPassword = async (
+  email: string,
+  authVerityToken: string,
+  newPassword: string,
+) => {
+  try {
+    const response = await apiClient.patch('/api/auth/password/reset', {
+      email,
+      authVerityToken,
+      newPassword,
+    });
+
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export const changePassword = async (currentPassword: string, newPassword: string) => {
   try {
     const response = await apiClient.patch('/api/auth/password', { currentPassword, newPassword });

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -54,6 +54,16 @@ export const registerUser = async (
   }
 };
 
+export const changePassword = async (currentPassword: string, newPassword: string) => {
+  try {
+    const response = await apiClient.patch('/api/auth/password', { currentPassword, newPassword });
+
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
 export const getAuth = async (email: string, password: string) => {
   try {
     const response = await apiClient.post('/api/auth/login', { email, password });

--- a/src/components/common/CustomHeader/index.tsx
+++ b/src/components/common/CustomHeader/index.tsx
@@ -26,6 +26,7 @@ const CustomHeader: React.FC<NativeStackHeaderProps> = ({ options, route }) => {
 
   const grayBGRoutes = [
     'Signup',
+    'FindPassword',
     'TrainingPuzzleSolve',
     'CommunityPuzzleSolve',
     'CreateCommunityPuzzle',

--- a/src/components/common/CustomHeader/index.tsx
+++ b/src/components/common/CustomHeader/index.tsx
@@ -31,6 +31,7 @@ const CustomHeader: React.FC<NativeStackHeaderProps> = ({ options, route }) => {
     'CreateCommunityPuzzle',
     'RankedPuzzleSolve',
     'ChangeNickname',
+    'ChangePassword',
   ];
   const backgroundColor = grayBGRoutes.includes(route.name)
     ? theme.color['gray/grayBG']

--- a/src/components/features/Board/AiThinkingIndicator/index.styles.tsx
+++ b/src/components/features/Board/AiThinkingIndicator/index.styles.tsx
@@ -1,0 +1,38 @@
+import { Animated, View } from 'react-native';
+import styled from 'styled-components';
+import theme from '../../../../styles/theme';
+
+export const IndicatorSlot = styled(View)`
+  position: absolute;
+  top: -38px;
+  left: 0;
+  right: 0;
+  align-items: center;
+  z-index: 10;
+`;
+
+export const ChipContainer = styled(View)`
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background-color: rgba(44, 47, 52, 0.88); /* gray/gray800 기반 반투명 */
+  shadow-color: ${theme.color['gray/black']};
+  shadow-offset: 0px 2px;
+  shadow-opacity: 0.12;
+  shadow-radius: 5px;
+  elevation: 3;
+`;
+
+export const DotsContainer = styled(View)`
+  flex-direction: row;
+  gap: 3px;
+`;
+
+export const Dot = styled(Animated.View)`
+  width: 4px;
+  height: 4px;
+  border-radius: 2px;
+  background-color: ${theme.color['gray/white']};
+`;

--- a/src/components/features/Board/AiThinkingIndicator/index.tsx
+++ b/src/components/features/Board/AiThinkingIndicator/index.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Animated, Easing } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { CustomText } from '../../../common';
+import { ChipContainer, Dot, DotsContainer, IndicatorSlot } from './index.styles';
+
+const FADE_DURATION_MS = 150;
+const DEEP_THINKING_DELAY_MS = 3000;
+const DOT_COUNT = 3;
+
+interface AiThinkingIndicatorProps {
+  visible: boolean;
+}
+
+const AiThinkingIndicator = ({ visible }: AiThinkingIndicatorProps) => {
+  const { t } = useTranslation();
+
+  const [isDeepThinking, setIsDeepThinking] = useState(false);
+  const chipOpacity = useRef(new Animated.Value(0)).current;
+  const dotOpacities = useRef(
+    Array.from({ length: DOT_COUNT }, () => new Animated.Value(0.3)),
+  ).current;
+
+  useEffect(() => {
+    Animated.timing(chipOpacity, {
+      toValue: visible ? 1 : 0,
+      duration: FADE_DURATION_MS,
+      useNativeDriver: true,
+    }).start(({ finished }) => {
+      // reset deep thinking state when the indicator is hidden
+      if (!visible && finished) {
+        setIsDeepThinking(false);
+      }
+    });
+
+    if (!visible) {
+      return;
+    }
+
+    const deepThinkingTimer = setTimeout(() => {
+      setIsDeepThinking(true);
+    }, DEEP_THINKING_DELAY_MS);
+
+    const dotAnimation = Animated.loop(
+      Animated.stagger(
+        160,
+        dotOpacities.map((opacity) =>
+          Animated.sequence([
+            Animated.timing(opacity, {
+              toValue: 1,
+              duration: 240,
+              easing: Easing.inOut(Easing.ease),
+              useNativeDriver: true,
+            }),
+            Animated.timing(opacity, {
+              toValue: 0.3,
+              duration: 240,
+              easing: Easing.inOut(Easing.ease),
+              useNativeDriver: true,
+            }),
+          ]),
+        ),
+      ),
+    );
+    dotAnimation.start();
+
+    return () => {
+      clearTimeout(deepThinkingTimer);
+      dotAnimation.stop();
+    };
+  }, [chipOpacity, dotOpacities, visible]);
+
+  return (
+    <IndicatorSlot pointerEvents="none">
+      <Animated.View style={{ opacity: chipOpacity }}>
+        <ChipContainer>
+          <CustomText size={12} color="gray/white">
+            {t(isDeepThinking ? 'puzzle.aiThinkingDeep' : 'puzzle.aiThinking')}
+          </CustomText>
+          <DotsContainer>
+            {dotOpacities.map((opacity, index) => (
+              <Dot key={index} style={{ opacity }} />
+            ))}
+          </DotsContainer>
+        </ChipContainer>
+      </Animated.View>
+    </IndicatorSlot>
+  );
+};
+
+export default AiThinkingIndicator;

--- a/src/components/features/Board/index.styles.tsx
+++ b/src/components/features/Board/index.styles.tsx
@@ -20,17 +20,6 @@ export const BoardBackground = styled(View)<{ boardWidth: number }>`
   background-color: ${theme.color['sub_color/beige/c']};
 `;
 
-export const LoadingWrapper = styled(View)`
-  flex: 1;
-  position: absolute;
-  justify-content: center;
-  align-items: center;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-`;
-
 export const FramContainer = styled(View)`
   position: absolute;
   border-width: 1.5px;

--- a/src/components/features/Board/index.tsx
+++ b/src/components/features/Board/index.tsx
@@ -47,7 +47,7 @@ export type StoneType = 0 | 1 | 2; // 0: Empty, 1: Black, 2: White
 type PuzzleAiBenchmarkMode = 'LOCAL_ONLY' | 'CACHE';
 type PuzzleAiAnswerSource = 'local-only' | 'cache-hit' | 'cache-miss' | 'cache-fallback';
 
-const PUZZLE_AI_BENCHMARK_MODE = 'LOCAL_ONLY' as PuzzleAiBenchmarkMode;
+const PUZZLE_AI_BENCHMARK_MODE = 'CACHE' as PuzzleAiBenchmarkMode;
 const IS_AI_BENCHMARK_ENABLED = __DEV__;
 
 const getPuzzleAiMode = (): PuzzleAiBenchmarkMode => {

--- a/src/components/features/Board/index.tsx
+++ b/src/components/features/Board/index.tsx
@@ -14,7 +14,6 @@ import {
   FrameRow,
   IndicatePoint,
   LastMoveHighlight,
-  LoadingWrapper,
   Stone,
   StoneRow,
 } from './index.styles';
@@ -30,9 +29,8 @@ import {
   positionToValue,
   valueToCoordinates,
 } from '../../../utils/utils';
-import { ActivityIndicator, NativeModules, ViewStyle } from 'react-native';
+import { Animated, Easing, NativeModules, ViewStyle } from 'react-native';
 import { CustomText, Icon } from '../../common';
-import theme from '../../../styles/theme';
 import { showBottomToast } from '../../common/Toast/toastMessage';
 import { useTranslation } from 'react-i18next';
 import {
@@ -41,13 +39,15 @@ import {
   savePuzzleCache,
 } from '../../../apis/puzzleCache';
 import useCancellableNativeRequest from '../../../hooks/useCancellableNativeRequest';
+import useDelayedVisibility from '../../../hooks/useDelayedVisibility';
+import AiThinkingIndicator from './AiThinkingIndicator';
 
 export type StoneType = 0 | 1 | 2; // 0: Empty, 1: Black, 2: White
 
 type PuzzleAiBenchmarkMode = 'LOCAL_ONLY' | 'CACHE';
 type PuzzleAiAnswerSource = 'local-only' | 'cache-hit' | 'cache-miss' | 'cache-fallback';
 
-const PUZZLE_AI_BENCHMARK_MODE = 'CACHE' as PuzzleAiBenchmarkMode;
+const PUZZLE_AI_BENCHMARK_MODE = 'LOCAL_ONLY' as PuzzleAiBenchmarkMode;
 const IS_AI_BENCHMARK_ENABLED = __DEV__;
 
 const getPuzzleAiMode = (): PuzzleAiBenchmarkMode => {
@@ -147,6 +147,8 @@ const Board = forwardRef<BoardRef, BoardProps>(function Board(
 
   const [isDisabled, setIsDisabled] = useState<boolean>(false);
   const [localSequence, setLocalSequence] = useState(sequence);
+
+  const isAiThinkingVisible = useDelayedVisibility(mode === 'solve' && isDisabled);
 
   const [history, setHistory] = useState<string[]>([sequence]);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -757,18 +759,48 @@ const Board = forwardRef<BoardRef, BoardProps>(function Board(
               stoneY={stoneY}
               sequence={cell.moveNumber}
               onPress={() => handleCellPress(x, y)}
+              pulseLastMove={isAiThinkingVisible}
             />
           ))}
         </StoneRow>
       ))}
-      {isDisabled && (
-        <LoadingWrapper>
-          <ActivityIndicator color={theme.color['main_color/yellow_p']} />
-        </LoadingWrapper>
-      )}
+      {mode === 'solve' && <AiThinkingIndicator visible={isAiThinkingVisible} />}
     </BoardBackground>
   );
 });
+
+// highlight the last move with a pulsing animation
+const PulsingLastMoveHighlight = ({ width }: { width: number }) => {
+  const scale = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    const pulse = Animated.loop(
+      Animated.sequence([
+        Animated.timing(scale, {
+          toValue: 1.5,
+          duration: 500,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(scale, {
+          toValue: 1,
+          duration: 500,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ]),
+    );
+    pulse.start();
+
+    return () => pulse.stop();
+  }, [scale]);
+
+  return (
+    <Animated.View style={{ transform: [{ scale }] }}>
+      <LastMoveHighlight width={width} />
+    </Animated.View>
+  );
+};
 
 interface CellProps {
   pos: string;
@@ -779,6 +811,7 @@ interface CellProps {
   sequence: number | null;
   onPress: () => void;
   showHighlights?: boolean;
+  pulseLastMove?: boolean;
   style?: ViewStyle;
 }
 
@@ -791,6 +824,7 @@ export const Cell = ({
   sequence,
   onPress,
   showHighlights = true,
+  pulseLastMove = false,
   style,
 }: CellProps) => {
   return (
@@ -803,7 +837,12 @@ export const Cell = ({
                 {sequence}
               </CustomText>
             ) : (
-              sequence === -1 && <LastMoveHighlight width={cellWidth / 3.3} />
+              sequence === -1 &&
+              (pulseLastMove ? (
+                <PulsingLastMoveHighlight width={cellWidth / 3.3} />
+              ) : (
+                <LastMoveHighlight width={cellWidth / 3.3} />
+              ))
             ))}
         </Stone>
       ) : showHighlights && pos === `${stoneX}-${stoneY}` ? (

--- a/src/hooks/useDelayedVisibility/index.ts
+++ b/src/hooks/useDelayedVisibility/index.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+
+interface UseDelayedVisibilityOptions {
+  showDelayMs?: number;
+  minVisibleMs?: number;
+}
+
+/**
+ * A custom React hook that manages the visibility of a component with a delay and minimum visible duration.
+ */
+const useDelayedVisibility = (
+  active: boolean,
+  { showDelayMs = 300, minVisibleMs = 500 }: UseDelayedVisibilityOptions = {},
+): boolean => {
+  const [visible, setVisible] = useState(false);
+  const visibleRef = useRef(false);
+  const shownAtRef = useRef(0);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    if (active) {
+      if (!visibleRef.current) {
+        timer = setTimeout(() => {
+          visibleRef.current = true;
+          shownAtRef.current = Date.now();
+          setVisible(true);
+        }, showDelayMs);
+      }
+    } else if (visibleRef.current) {
+      const remainingMs = minVisibleMs - (Date.now() - shownAtRef.current);
+      if (remainingMs <= 0) {
+        visibleRef.current = false;
+        setVisible(false);
+      } else {
+        timer = setTimeout(() => {
+          visibleRef.current = false;
+          setVisible(false);
+        }, remainingMs);
+      }
+    }
+
+    return () => {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    };
+  }, [active, showDelayMs, minVisibleMs]);
+
+  return visible;
+};
+
+export default useDelayedVisibility;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,7 +27,8 @@
     },
     "changePassword": {
       "prefix": "To use from now on,",
-      "title": "Enter a new password"
+      "title": "Enter a new password",
+      "description": "Enter your current password to verify your identity."
     },
     "resetPassword": {
       "prefix": "The one you signed up with,",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,6 +24,10 @@
       "prefix": "To represent you,",
       "title": "Enter a nickname",
       "description": "Use 2 to 8 letters or numbers. (Excluding special characters)"
+    },
+    "changePassword": {
+      "prefix": "To use from now on,",
+      "title": "Enter a new password"
     }
   },
   "common": {
@@ -38,6 +42,7 @@
   "settings": {
     "language": "Language",
     "changeNickname": "Change Nickname",
+    "changePassword": "Change Password",
     "removeAds": "Remove Ads",
     "privacyPolicy": "Privacy Policy",
     "termsOfService": "Terms of Service",
@@ -61,6 +66,9 @@
     "code": "Verification Code",
     "password": "Password",
     "confirmPassword": "Confirm Password",
+    "currentPassword": "Current Password",
+    "newPassword": "New Password",
+    "confirmNewPassword": "Confirm New Password",
     "nickname": "Nickname",
     "description": "Enter description",
     "communitySearch": "Enter author or puzzle No."
@@ -263,6 +271,9 @@
     "nicknameAlreadyInUse": "This nickname is already in use.",
     "nicknameChanged": "Nickname changed.",
     "nicknameChangeFailed": "Failed to change nickname.",
+
+    "passwordChanged": "Password changed.",
+    "passwordChangeFailed": "Failed to change password.",
 
     "enterEmail": "Enter your email.",
     "enterPassword": "Enter your password.",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -237,7 +237,9 @@
     },
     "author": "'s puzzle",
     "createDescription": "Click on the board to create a puzzle. Pay attention to the order of black and white stones.",
-    "verifyDescription": "Get AI certification using the verify button. You can still publish even if it is not certified."
+    "verifyDescription": "Get AI certification using the verify button. You can still publish even if it is not certified.",
+    "aiThinking": "Thinking of a move",
+    "aiThinkingDeep": "Taking its time"
   },
   "ranking": {
     "title": "Ranking",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -28,6 +28,11 @@
     "changePassword": {
       "prefix": "To use from now on,",
       "title": "Enter a new password"
+    },
+    "resetPassword": {
+      "prefix": "The one you signed up with,",
+      "title": "Enter your email address",
+      "description": "A verification email will be sent to this address."
     }
   },
   "common": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -28,6 +28,11 @@
     "changePassword": {
       "prefix": "새롭게 사용할",
       "title": "비밀번호를 입력해 주세요"
+    },
+    "resetPassword": {
+      "prefix": "가입할 때 사용한",
+      "title": "이메일을 입력해 주세요",
+      "description": "해당 메일주소로 인증 메일을 보내드립니다."
     }
   },
   "common": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -237,7 +237,9 @@
     },
     "author": "님 출제",
     "createDescription": "보드를 클릭하여 문제를 만들어 보세요. 흑돌과 백돌 순서에 주의하세요.",
-    "verifyDescription": "검증 버튼으로 AI 인증을 받으세요. 인증되지 않아도 출제 가능해요."
+    "verifyDescription": "검증 버튼으로 AI 인증을 받으세요. 인증되지 않아도 출제 가능해요.",
+    "aiThinking": "다음 수를 생각하고 있어요",
+    "aiThinkingDeep": "신중하게 두는 중이에요"
   },
   "ranking": {
     "title": "랭킹",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -27,7 +27,8 @@
     },
     "changePassword": {
       "prefix": "새롭게 사용할",
-      "title": "비밀번호를 입력해 주세요"
+      "title": "비밀번호를 입력해 주세요",
+      "description": "본인 확인을 위해 현재 비밀번호를 입력해 주세요."
     },
     "resetPassword": {
       "prefix": "가입할 때 사용한",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -24,6 +24,10 @@
       "prefix": "당신을 나타낼",
       "title": "닉네임을 입력해 주세요",
       "description": "2~8자의 문자나 숫자만 가능해요. (특수문자 제외)"
+    },
+    "changePassword": {
+      "prefix": "새롭게 사용할",
+      "title": "비밀번호를 입력해 주세요"
     }
   },
   "common": {
@@ -38,6 +42,7 @@
   "settings": {
     "language": "언어 설정",
     "changeNickname": "닉네임 변경",
+    "changePassword": "비밀번호 변경",
     "removeAds": "광고 제거",
     "privacyPolicy": "개인정보 처리방침",
     "termsOfService": "이용 약관",
@@ -61,6 +66,9 @@
     "code": "인증번호",
     "password": "비밀번호",
     "confirmPassword": "비밀번호 확인",
+    "currentPassword": "현재 비밀번호",
+    "newPassword": "새 비밀번호",
+    "confirmNewPassword": "새 비밀번호 확인",
     "nickname": "닉네임",
     "description": "설명 입력",
     "communitySearch": "출제자 또는 문제번호 검색"
@@ -263,6 +271,9 @@
     "nicknameAlreadyInUse": "이미 사용된 닉네임입니다.",
     "nicknameChanged": "닉네임이 변경되었습니다.",
     "nicknameChangeFailed": "닉네임 변경에 실패했습니다.",
+
+    "passwordChanged": "비밀번호가 변경되었습니다.",
+    "passwordChangeFailed": "비밀번호 변경에 실패했습니다.",
 
     "enterEmail": "이메일을 입력해주세요.",
     "enterPassword": "비밀번호를 입력해주세요.",

--- a/src/screens/FindPassword/FindPasswordCodeStep/index.tsx
+++ b/src/screens/FindPassword/FindPasswordCodeStep/index.tsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BottomButtonBar, CustomText, CustomTextInput } from '../../../components/common';
+import HelperText from '../../../components/common/HelperText';
+import { confirmCode, sendPasswordResetCode } from '../../../apis/auth';
+import { showBottomToast } from '../../../components/common/Toast/toastMessage';
+import { HelperWrapper, InputWithHelperWrapper, LabelWrapper } from '../../Signup/index.styles';
+
+interface FindPasswordCodeStepProps {
+  code: string;
+  setCode: (code: string) => void;
+  email: string;
+  setAuthVerityToken: (authVerityToken: string) => void;
+  onNext: () => void;
+}
+
+const FindPasswordCodeStep = ({
+  code,
+  setCode,
+  email,
+  setAuthVerityToken,
+  onNext,
+}: FindPasswordCodeStepProps) => {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const transition = [
+    {
+      text: t('button.resend'),
+      onAction: async () => {
+        handleResend();
+      },
+      disabled: isLoading,
+    },
+    {
+      text: t('button.confirm'),
+      onAction: async () => {
+        codeConfirm();
+      },
+      disabled: code.length === 0 || isLoading,
+    },
+  ];
+
+  const handleResend = async () => {
+    try {
+      setIsLoading(true);
+      await sendPasswordResetCode(email);
+    } catch (error) {
+      showBottomToast('error', error as string);
+    }
+    setIsLoading(false);
+  };
+
+  const codeConfirm = async () => {
+    try {
+      setIsLoading(true);
+      const response = await confirmCode(email, code);
+      const token = response?.response?.authVerityToken;
+      if (response?.isSuccess && token) {
+        setAuthVerityToken(token);
+        onNext();
+      } else {
+        showBottomToast('error', response?.errorResponse?.message as string);
+      }
+    } catch (error) {
+      showBottomToast('error', error as string);
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <>
+      <LabelWrapper>
+        <CustomText size={18} lineHeight="lg">
+          {t('auth.enterCode.prefix')}
+        </CustomText>
+        <CustomText size={18} lineHeight="lg" weight="bold">
+          {t('auth.enterCode.title')}
+        </CustomText>
+      </LabelWrapper>
+
+      <InputWithHelperWrapper>
+        <CustomTextInput
+          placeholder={t('placeholder.code')}
+          value={code}
+          onChangeText={setCode}
+          keyboardType="numeric"
+        />
+        <HelperWrapper>
+          <HelperText type="info">{t('auth.enterCode.description')}</HelperText>
+        </HelperWrapper>
+      </InputWithHelperWrapper>
+
+      <BottomButtonBar transitions={transition} />
+    </>
+  );
+};
+
+export default FindPasswordCodeStep;

--- a/src/screens/FindPassword/FindPasswordEmailStep/index.tsx
+++ b/src/screens/FindPassword/FindPasswordEmailStep/index.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BottomButtonBar, CustomText, CustomTextInput } from '../../../components/common';
+import HelperText from '../../../components/common/HelperText';
+import { emailRegex } from '../../../utils/validators';
+import { sendPasswordResetCode } from '../../../apis/auth';
+import { showBottomToast } from '../../../components/common/Toast/toastMessage';
+import { HelperWrapper, InputWithHelperWrapper, LabelWrapper } from '../../Signup/index.styles';
+
+interface FindPasswordEmailStepProps {
+  email: string;
+  setEmail: (email: string) => void;
+  onNext: () => void;
+}
+
+const FindPasswordEmailStep = ({ email, setEmail, onNext }: FindPasswordEmailStepProps) => {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isEmailValid, setIsEmailValid] = useState<boolean>(false);
+
+  const transition = [
+    {
+      text: t('button.sendEmail'),
+      onAction: async () => {
+        handleSendEmail();
+      },
+      disabled: !isEmailValid || isLoading,
+    },
+  ];
+
+  const handleSendEmail = async () => {
+    if (isEmailValid) {
+      try {
+        setIsLoading(true);
+        await sendPasswordResetCode(email);
+        onNext();
+      } catch (msg) {
+        showBottomToast('error', msg as string);
+      }
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setIsEmailValid(email !== '' && emailRegex.test(email));
+  }, [email]);
+
+  return (
+    <>
+      <LabelWrapper>
+        <CustomText size={18} lineHeight="lg">
+          {t('auth.resetPassword.prefix')}
+        </CustomText>
+        <CustomText size={18} lineHeight="lg" weight="bold">
+          {t('auth.resetPassword.title')}
+        </CustomText>
+      </LabelWrapper>
+
+      <InputWithHelperWrapper>
+        <CustomTextInput
+          placeholder={t('placeholder.email')}
+          value={email}
+          onChangeText={setEmail}
+          keyboardType="email-address"
+        />
+        <HelperWrapper>
+          <HelperText type="info">{t('auth.resetPassword.description')}</HelperText>
+        </HelperWrapper>
+      </InputWithHelperWrapper>
+
+      <BottomButtonBar transitions={transition} />
+    </>
+  );
+};
+
+export default FindPasswordEmailStep;

--- a/src/screens/FindPassword/FindPasswordNewPasswordStep/index.tsx
+++ b/src/screens/FindPassword/FindPasswordNewPasswordStep/index.tsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BottomButtonBar, CustomText, CustomTextInput } from '../../../components/common';
+import HelperText from '../../../components/common/HelperText';
+import { passwordRegex } from '../../../utils/validators';
+import { HelperWrapper, InputWithHelperWrapper, LabelWrapper } from '../../Signup/index.styles';
+
+interface FindPasswordNewPasswordStepProps {
+  password: string;
+  setPassword: (password: string) => void;
+  onComplete: () => Promise<void>;
+  isLoading?: boolean;
+}
+
+const FindPasswordNewPasswordStep = ({
+  password,
+  setPassword,
+  onComplete,
+  isLoading = false,
+}: FindPasswordNewPasswordStepProps) => {
+  const { t } = useTranslation();
+  const [confirmPassword, setConfirmPassword] = useState<string>('');
+  const [isPasswordValid, setIsPasswordValid] = useState<boolean>(false);
+
+  const transition = [
+    {
+      text: t('button.confirm'),
+      onAction: onComplete,
+      disabled: !isPasswordValid || isLoading,
+    },
+  ];
+
+  useEffect(() => {
+    setIsPasswordValid(
+      passwordRegex.test(password) && confirmPassword === password && confirmPassword !== '',
+    );
+  }, [password, confirmPassword]);
+
+  const passwordHelper = () => {
+    if (password === '') {
+      return <HelperText type="info">{t('auth.enterPassword.description')}</HelperText>;
+    }
+    if (passwordRegex.test(password)) {
+      return <HelperText type="checked">{t('auth.enterPassword.description')}</HelperText>;
+    }
+    return <HelperText type="error">{t('auth.enterPassword.description')}</HelperText>;
+  };
+
+  const confirmPasswordHelper = () => {
+    if (confirmPassword === '' || !passwordRegex.test(password)) {
+      return null;
+    }
+    if (confirmPassword === password) {
+      return <HelperText type="checked">{t('auth.enterPassword.passwordMatch')}</HelperText>;
+    }
+    return <HelperText type="error">{t('auth.enterPassword.passwordMisMatch')}</HelperText>;
+  };
+
+  return (
+    <>
+      <LabelWrapper>
+        <CustomText size={18} lineHeight="lg">
+          {t('auth.changePassword.prefix')}
+        </CustomText>
+        <CustomText size={18} lineHeight="lg" weight="bold">
+          {t('auth.changePassword.title')}
+        </CustomText>
+      </LabelWrapper>
+
+      <InputWithHelperWrapper>
+        <CustomTextInput
+          placeholder={t('placeholder.newPassword')}
+          value={password}
+          onChangeText={setPassword}
+          isPassword
+        />
+        <HelperWrapper>{passwordHelper()}</HelperWrapper>
+      </InputWithHelperWrapper>
+
+      <InputWithHelperWrapper>
+        <CustomTextInput
+          placeholder={t('placeholder.confirmNewPassword')}
+          value={confirmPassword}
+          onChangeText={setConfirmPassword}
+          isPassword
+        />
+        <HelperWrapper>{confirmPasswordHelper()}</HelperWrapper>
+      </InputWithHelperWrapper>
+
+      <BottomButtonBar transitions={transition} />
+    </>
+  );
+};
+
+export default FindPasswordNewPasswordStep;

--- a/src/screens/FindPassword/index.styles.ts
+++ b/src/screens/FindPassword/index.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import theme from '../../styles/theme';
+import DismissKeyboardView from '../../components/common/DismissKeyboadView';
+
+export const FindPasswordContainer = styled(DismissKeyboardView)`
+  flex: 1;
+  background-color: ${theme.color['gray/grayBG']};
+`;

--- a/src/screens/FindPassword/index.tsx
+++ b/src/screens/FindPassword/index.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import { ParamListBase, useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { useTranslation } from 'react-i18next';
+import { FindPasswordContainer } from './index.styles';
+import FindPasswordEmailStep from './FindPasswordEmailStep';
+import FindPasswordCodeStep from './FindPasswordCodeStep';
+import FindPasswordNewPasswordStep from './FindPasswordNewPasswordStep';
+import { resetPassword } from '../../apis/auth';
+import { showBottomToast } from '../../components/common/Toast/toastMessage';
+
+enum FindPasswordStep {
+  Email,
+  Code,
+  Password,
+}
+
+const FindPassword = () => {
+  const { t } = useTranslation();
+  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+  const [step, setStep] = useState<FindPasswordStep>(FindPasswordStep.Email);
+  const [email, setEmail] = useState<string>('');
+  const [code, setCode] = useState<string>('');
+  const [authVerityToken, setAuthVerityToken] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const handleResetComplete = async () => {
+    if (!email || !authVerityToken || !password) {
+      showBottomToast('error', t('toast.missingRequiredFields'));
+      setStep(FindPasswordStep.Email);
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const response = await resetPassword(email, authVerityToken, password);
+      if (response?.isSuccess) {
+        navigation.goBack();
+        showBottomToast('success', t('toast.passwordChanged'));
+      } else {
+        showBottomToast('error', response?.errorResponse?.message as string);
+      }
+    } catch (error) {
+      showBottomToast('error', error as string);
+    }
+    setIsLoading(false);
+  };
+
+  return (
+    <FindPasswordContainer>
+      {step === FindPasswordStep.Email && (
+        <FindPasswordEmailStep
+          email={email}
+          setEmail={setEmail}
+          onNext={() => setStep(FindPasswordStep.Code)}
+        />
+      )}
+      {step === FindPasswordStep.Code && (
+        <FindPasswordCodeStep
+          code={code}
+          setCode={setCode}
+          email={email}
+          setAuthVerityToken={setAuthVerityToken}
+          onNext={() => setStep(FindPasswordStep.Password)}
+        />
+      )}
+      {step === FindPasswordStep.Password && (
+        <FindPasswordNewPasswordStep
+          password={password}
+          setPassword={setPassword}
+          onComplete={handleResetComplete}
+          isLoading={isLoading}
+        />
+      )}
+    </FindPasswordContainer>
+  );
+};
+
+export default FindPassword;

--- a/src/screens/Settings/ChangePassword/index.styles.ts
+++ b/src/screens/Settings/ChangePassword/index.styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import theme from '../../../styles/theme';
+import DismissKeyboardView from '../../../components/common/DismissKeyboadView';
+
+export const Container = styled(DismissKeyboardView)`
+  background-color: ${theme.color['gray/grayBG']};
+  flex: 1;
+  position: relative;
+`;

--- a/src/screens/Settings/ChangePassword/index.tsx
+++ b/src/screens/Settings/ChangePassword/index.tsx
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ParamListBase, useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { BottomButtonBar, CustomText, CustomTextInput } from '../../../components/common';
+import HelperText from '../../../components/common/HelperText';
+import { showBottomToast } from '../../../components/common/Toast/toastMessage';
+import { changePassword } from '../../../apis/auth';
+import { passwordRegex } from '../../../utils/validators';
+import { HelperWrapper, InputWithHelperWrapper, LabelWrapper } from '../../Signup/index.styles';
+import { Container } from './index.styles';
+
+const ChangePassword = () => {
+  const { t } = useTranslation();
+  const navigation = useNavigation<NativeStackNavigationProp<ParamListBase>>();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isFormValid, setIsFormValid] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsFormValid(
+      currentPassword !== '' &&
+        passwordRegex.test(newPassword) &&
+        confirmPassword === newPassword &&
+        confirmPassword !== '',
+    );
+  }, [currentPassword, newPassword, confirmPassword]);
+
+  const handleConfirm = async () => {
+    try {
+      setIsLoading(true);
+      await changePassword(currentPassword, newPassword);
+      navigation.goBack();
+      showBottomToast('success', t('toast.passwordChanged'));
+    } catch (error) {
+      showBottomToast('error', t('toast.passwordChangeFailed'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const transition = [
+    {
+      text: t('button.confirm'),
+      onAction: handleConfirm,
+      disabled: !isFormValid || isLoading,
+    },
+  ];
+
+  const newPasswordHelper = () => {
+    if (newPassword === '') {
+      return <HelperText type="info">{t('auth.enterPassword.description')}</HelperText>;
+    }
+    if (passwordRegex.test(newPassword)) {
+      return <HelperText type="checked">{t('auth.enterPassword.description')}</HelperText>;
+    }
+    return <HelperText type="error">{t('auth.enterPassword.description')}</HelperText>;
+  };
+
+  const confirmPasswordHelper = () => {
+    if (confirmPassword === '' || !passwordRegex.test(newPassword)) {
+      return null;
+    }
+    if (confirmPassword === newPassword) {
+      return <HelperText type="checked">{t('auth.enterPassword.passwordMatch')}</HelperText>;
+    }
+    return <HelperText type="error">{t('auth.enterPassword.passwordMisMatch')}</HelperText>;
+  };
+
+  return (
+    <Container>
+      <LabelWrapper>
+        <CustomText size={18} lineHeight="lg">
+          {t('auth.changePassword.prefix')}
+        </CustomText>
+        <CustomText size={18} lineHeight="lg" weight="bold">
+          {t('auth.changePassword.title')}
+        </CustomText>
+      </LabelWrapper>
+
+      <InputWithHelperWrapper>
+        <CustomTextInput
+          placeholder={t('placeholder.currentPassword')}
+          value={currentPassword}
+          onChangeText={setCurrentPassword}
+          isPassword
+        />
+        <HelperWrapper />
+      </InputWithHelperWrapper>
+
+      <InputWithHelperWrapper>
+        <CustomTextInput
+          placeholder={t('placeholder.newPassword')}
+          value={newPassword}
+          onChangeText={setNewPassword}
+          isPassword
+        />
+        <HelperWrapper>{newPasswordHelper()}</HelperWrapper>
+      </InputWithHelperWrapper>
+
+      <InputWithHelperWrapper>
+        <CustomTextInput
+          placeholder={t('placeholder.confirmNewPassword')}
+          value={confirmPassword}
+          onChangeText={setConfirmPassword}
+          isPassword
+        />
+        <HelperWrapper>{confirmPasswordHelper()}</HelperWrapper>
+      </InputWithHelperWrapper>
+
+      <BottomButtonBar transitions={transition} />
+    </Container>
+  );
+};
+
+export default ChangePassword;

--- a/src/screens/Settings/ChangePassword/index.tsx
+++ b/src/screens/Settings/ChangePassword/index.tsx
@@ -87,7 +87,9 @@ const ChangePassword = () => {
           onChangeText={setCurrentPassword}
           isPassword
         />
-        <HelperWrapper />
+        <HelperWrapper>
+          <HelperText type="info">{t('auth.changePassword.description')}</HelperText>
+        </HelperWrapper>
       </InputWithHelperWrapper>
 
       <InputWithHelperWrapper>

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -68,6 +68,7 @@ const Settings = () => {
   const menuItems = [
     { label: t('settings.language'), onPress: () => navigation.navigate('Language') },
     { label: t('settings.changeNickname'), onPress: () => navigation.navigate('ChangeNickname') },
+    { label: t('settings.changePassword'), onPress: () => navigation.navigate('ChangePassword') },
     { label: t('settings.removeAds'), onPress: () => handleRemoveAds },
     {
       label: t('settings.privacyPolicy'),

--- a/src/screens/Signin/index.tsx
+++ b/src/screens/Signin/index.tsx
@@ -89,12 +89,14 @@ const Signin = () => {
               {t('auth.signup')}
             </CustomText>
           </NavigationButton>
-          {/* TODO: 비밀번호 찾기 기능 */}
-          {/* <NavigationButton>
+          <NavigationButton
+            onPress={() => {
+              navigation.navigate('FindPassword');
+            }}>
             <CustomText size={12} lineHeight="sm" color="gray/gray500">
               {t('auth.findPassword')}
             </CustomText>
-          </NavigationButton> */}
+          </NavigationButton>
         </NavigationWrapper>
       </SigninWrapper>
 

--- a/src/types/MenuThemeMap/index.ts
+++ b/src/types/MenuThemeMap/index.ts
@@ -97,6 +97,13 @@ export const menuThemeMap = {
     iconName: 'SettingIcon',
     route: 'ChangeNickname',
   },
+  changePassword: {
+    titleKey: 'settings.changePassword',
+    background: 'gray/gray100',
+    iconColor: 'gray/gray400',
+    iconName: 'SettingIcon',
+    route: 'ChangePassword',
+  },
   signup: {
     titleKey: 'auth.signup',
     background: 'sub_color/indigo/bg',
@@ -124,6 +131,7 @@ export const headerMenuTypeMap = {
   Settings: 'settings',
   Language: 'language',
   ChangeNickname: 'changeNickname',
+  ChangePassword: 'changePassword',
   TrainingPacks: 'trainingPuzzle',
   TrainingPuzzles: 'trainingPuzzle',
   TrainingPuzzleSolve: 'trainingPuzzle',

--- a/src/types/MenuThemeMap/index.ts
+++ b/src/types/MenuThemeMap/index.ts
@@ -111,6 +111,13 @@ export const menuThemeMap = {
     iconName: 'LogoIcon',
     route: null,
   },
+  findPassword: {
+    titleKey: 'auth.findPassword',
+    background: 'sub_color/indigo/bg',
+    iconColor: 'main_color/blue_p',
+    iconName: 'LogoIcon',
+    route: null,
+  },
   home: {
     titleKey: 'common.appName',
     background: 'sub_color/indigo/bg',
@@ -125,6 +132,7 @@ export type MenuType = keyof typeof menuThemeMap;
 export const headerMenuTypeMap = {
   Home: 'home',
   Signup: 'signup',
+  FindPassword: 'findPassword',
   MyPuzzles: 'myPuzzle',
   LikedPuzzles: 'likes',
   Ranking: 'ranking',


### PR DESCRIPTION
## ✨ Summary

비밀번호 변경 API 2종을 연동하고 관련 화면을 추가했습니다.

### 비밀번호 변경 (로그인 상태)
- 설정 > 닉네임 변경 아래 "비밀번호 변경" 메뉴 추가
- 현재 비밀번호 확인 후 새 비밀번호로 변경 (`PATCH /api/auth/password`)
- 새 비밀번호 유효성 검증 및 확인 입력 (기존 회원가입 규칙 재사용)

### 비밀번호 재설정 (로그인 전)
- 로그인 화면의 "비밀번호 찾기" 버튼 활성화 (기존 TODO 주석 해제)
- 이메일 인증 → 인증코드 확인 → 새 비밀번호 설정 3단계 플로우 (회원가입과 동일한 스텝 구조)
- `POST /api/auth/password/reset/email`, `PATCH /api/auth/password/reset` 연동, 인증코드 확인은 기존 `confirmCode` 재사용

### 기타
- ko/en 다국어 키 추가 (설정 메뉴, 재설정 안내 문구, 토스트)
- 헤더 테마 매핑 추가 (ChangePassword: 설정 테마, FindPassword: 회원가입 테마)
- `npm audit fix`로 라이브러리 취약점 개선 버전 업그레이드

---

## AI 로딩 UI 개선

### 배경

AI가 다음 수를 계산하는 동안 보드 정중앙에 기본 `ActivityIndicator` 스피너만 표시되어, 시스템 로딩처럼 보이고 사용자가 수를 구상해야 할 보드를 가리는 문제가 있었습니다. 캐시 히트 시에는 스피너가 수십 ms 만에 사라져 깜빡임도 발생했습니다.

### 변경 내용

**1. AI 생각 중 인디케이터 신설 (`AiThinkingIndicator`)**
- 보드 중앙 스피너 오버레이를 제거하고, 보드 상단 바깥에 떠 있는 알약 형태 칩으로 교체
- 반투명 다크 그레이 배경(`rgba(44,47,52,0.88)`) + 흰색 텍스트 + 순차적으로 맥동하는 점 3개 애니메이션
- 절대 위치(absolute)라 주변 레이아웃에 영향 없음, `pointerEvents="none"`으로 터치 미간섭
- 3초 이상 길어지면 문구가 자동 전환: "다음 수를 생각하고 있어요" → "신중하게 두는 중이에요" (en 포함, i18n 키 `puzzle.aiThinking` / `puzzle.aiThinkingDeep` 추가)
- solve 모드에서만 렌더링 (출제/검토 화면 영향 없음)

**2. 마지막 착수 펄스 애니메이션**
- AI가 생각하는 동안 사용자가 방금 둔 돌의 하이라이트가 은은하게 맥동(scale 1.0↔1.5 반복)하여 "이 수를 받아 읽는 중"이라는 맥락 전달

**3. 깜빡임 방지 (`useDelayedVisibility` 훅 신설)**
- 로딩이 300ms 안에 끝나면(캐시 히트) 인디케이터를 아예 표시하지 않음
- 한번 표시되면 최소 500ms 유지 후 페이드 아웃
- 페이드 아웃 완료 후에 장고 문구 상태를 리셋하여 사라지는 도중 문구가 되돌아가는 현상 방지