### PR TITLE
feat: improve puzzle cache logic

### DIFF
--- a/src/apis/puzzleCache.ts
+++ b/src/apis/puzzleCache.ts
@@ -8,25 +8,32 @@ export interface PuzzleCacheRequest {
   currentBoardState: string;
 }
 
-export interface PuzzleCacheAiResponse {
-  position: string | null;
+export interface NextMoveCandidate {
+  userMove: string;
+  aiResponse: string;
 }
 
-export const getPuzzleCacheAiResponse = async ({
+export interface NextMovesRequest {
+  puzzleType: PuzzleCacheType;
+  puzzleId: number;
+  userTurnBoardState: string;
+}
+
+export const getPuzzleCacheNextMoves = async ({
   puzzleType,
   puzzleId,
-  currentBoardState,
-}: PuzzleCacheRequest): Promise<PuzzleCacheAiResponse> => {
+  userTurnBoardState,
+}: NextMovesRequest): Promise<NextMoveCandidate[]> => {
   try {
-    const response = await apiClient.get('/api/puzzle/cache/ai-response', {
+    const response = await apiClient.get('/api/puzzle/cache/next-moves', {
       params: {
         puzzleType,
         puzzleId,
-        currentBoardState,
+        userTurnBoardState,
       },
     });
 
-    return response.data.response;
+    return response.data.response ?? [];
   } catch (error) {
     throw error;
   }

--- a/src/components/features/Board/index.tsx
+++ b/src/components/features/Board/index.tsx
@@ -34,7 +34,7 @@ import { CustomText, Icon } from '../../common';
 import { showBottomToast } from '../../common/Toast/toastMessage';
 import { useTranslation } from 'react-i18next';
 import {
-  getPuzzleCacheAiResponse,
+  getPuzzleCacheNextMoves,
   PuzzleCacheType,
   savePuzzleCache,
 } from '../../../apis/puzzleCache';
@@ -304,6 +304,50 @@ const Board = forwardRef<BoardRef, BoardProps>(function Board(
     [currentIndex, history, localSequence, makeMode, mode, setSequence],
   );
 
+  // 사용자 차례의 보드 상태별로 미리 받아둔 (사용자 수 -> AI 응답) 후보 목록
+  const nextMovesPrefetchRef = useRef<{
+    boardState: string;
+    promise: Promise<Map<string, string> | null>;
+  } | null>(null);
+
+  const prefetchNextMoves = useCallback(
+    (userTurnBoardState: string) => {
+      if (!puzzleCache || getPuzzleAiMode() !== 'CACHE') {
+        return;
+      }
+
+      if (nextMovesPrefetchRef.current?.boardState === userTurnBoardState) {
+        return;
+      }
+
+      const prefetchStartedAt = IS_AI_BENCHMARK_ENABLED ? Date.now() : 0;
+      const promise = getPuzzleCacheNextMoves({
+        ...puzzleCache,
+        userTurnBoardState,
+      })
+        .then((candidates) => {
+          if (IS_AI_BENCHMARK_ENABLED) {
+            console.log('[AiBenchmark] next-moves prefetch:', {
+              puzzleType: puzzleCache.puzzleType,
+              puzzleId: puzzleCache.puzzleId,
+              boardDepth: getSequenceDepth(userTurnBoardState),
+              candidateCount: candidates.length,
+              ms: Date.now() - prefetchStartedAt,
+            });
+          }
+
+          return new Map(candidates.map((candidate) => [candidate.userMove, candidate.aiResponse]));
+        })
+        .catch((error) => {
+          console.log('AI next-moves prefetch failed:', error);
+          return null;
+        });
+
+      nextMovesPrefetchRef.current = { boardState: userTurnBoardState, promise };
+    },
+    [puzzleCache],
+  );
+
   const getCachedAiAnswer = useCallback(
     async (
       userSequence: string,
@@ -317,27 +361,39 @@ const Board = forwardRef<BoardRef, BoardProps>(function Board(
         return { answer: null, shouldSave: false };
       }
 
-      try {
-        const cacheStartedAt = IS_AI_BENCHMARK_ENABLED ? Date.now() : 0;
-        const cache = await getPuzzleCacheAiResponse({
-          ...puzzleCache,
-          currentBoardState: userSequence,
-        });
-        const cacheLookupMs = IS_AI_BENCHMARK_ENABLED ? Date.now() - cacheStartedAt : undefined;
-
-        if (!cache.position) {
-          return { answer: null, shouldSave: true, cacheLookupMs, position: null };
-        }
-
-        const cachedAnswer = positionToValue(cache.position);
-
-        return { answer: cachedAnswer, shouldSave: false, cacheLookupMs, position: cache.position };
-      } catch (error) {
-        console.log('AI cache request failed:', error);
+      const lastMoveMatch = userSequence.match(/[a-o](?:1[0-5]|[1-9])$/);
+      if (!lastMoveMatch) {
         return { answer: null, shouldSave: false };
       }
+
+      const userMove = lastMoveMatch[0];
+      const userTurnBoardState = userSequence.slice(0, -userMove.length);
+
+      // 미리 받아둔 목록이 없거나 다른 보드 상태의 것이라면 이 시점에 조회
+      prefetchNextMoves(userTurnBoardState);
+      const prefetch = nextMovesPrefetchRef.current;
+      if (!prefetch || prefetch.boardState !== userTurnBoardState) {
+        return { answer: null, shouldSave: false };
+      }
+
+      const cacheStartedAt = IS_AI_BENCHMARK_ENABLED ? Date.now() : 0;
+      const nextMoves = await prefetch.promise;
+      const cacheLookupMs = IS_AI_BENCHMARK_ENABLED ? Date.now() - cacheStartedAt : undefined;
+
+      if (!nextMoves) {
+        return { answer: null, shouldSave: false, cacheLookupMs };
+      }
+
+      const position = nextMoves.get(userMove) ?? null;
+      if (!position) {
+        return { answer: null, shouldSave: true, cacheLookupMs, position: null };
+      }
+
+      const cachedAnswer = positionToValue(position);
+
+      return { answer: cachedAnswer, shouldSave: false, cacheLookupMs, position };
     },
-    [puzzleCache],
+    [prefetchNextMoves, puzzleCache],
   );
 
   const saveAiAnswerCache = useCallback(
@@ -558,6 +614,9 @@ const Board = forwardRef<BoardRef, BoardProps>(function Board(
             return;
           }
 
+          // 다시 사용자 차례가 되었으므로, 다음 수 후보 목록을 미리 받아둔다
+          prefetchNextMoves(newSequence);
+
           updateBoard(x, y, aiIsBlackTurn);
           setIsBlackTurn(!aiIsBlackTurn);
           finishAiRequest(requestId);
@@ -582,6 +641,7 @@ const Board = forwardRef<BoardRef, BoardProps>(function Board(
       getCachedAiAnswer,
       isActiveAiRequest,
       logAiBenchmark,
+      prefetchNextMoves,
       puzzleCache,
       saveAiAnswerCache,
       scheduleAiRequest,
@@ -733,6 +793,13 @@ const Board = forwardRef<BoardRef, BoardProps>(function Board(
   useEffect(() => {
     initializeBoard();
   }, [initializeBoard]);
+
+  // solve 모드 진입 시(사용자 차례) 다음 수 후보 목록을 미리 받아둔다
+  useEffect(() => {
+    if (mode === 'solve') {
+      prefetchNextMoves(sequence);
+    }
+  }, [mode, prefetchNextMoves, sequence]);
 
   return (
     <BoardBackground boardWidth={boardWidth}>


### PR DESCRIPTION
## 개요

퍼즐 캐시 조회를 착수 후 단건 조회 방식에서 **사용자 차례에 미리 후보 목록을 받아두는 prefetch 방식**으로 변경합니다.

기존에는 사용자가 돌을 놓은 뒤 `/api/puzzle/cache/ai-response`를 호출해 네트워크 왕복만큼 대기가 발생했습니다. 이제 새로 추가된 `/api/puzzle/cache/next-moves`로 사용자가 고민하는 동안 가능한 모든 (사용자 수 → AI 응답) 목록을 미리 받아두고, 착수 시 로컬 Map에서 즉시 조회합니다. 캐시 히트 시 체감 지연이 사실상 0ms가 됩니다.

## 변경 사항

- `getPuzzleCacheAiResponse` 제거, `getPuzzleCacheNextMoves` 추가 (`puzzleCache.ts`)
- Board에 prefetch 로직 추가 (`Board/index.tsx`)
  - prefetch 시점: ① solve 모드 진입 직후 ② AI 착수 후 사용자 차례 전환 시
  - 착수 시 prefetch된 Map에서 마지막 수로 즉시 조회
  - prefetch가 없거나 보드 상태가 다르면 그 시점에 조회 (기존과 동일한 지연으로 fallback)
- 벤치마크 로그에 `next-moves prefetch` (소요 시간·후보 개수) 추가

## 유지되는 동작

- 캐시 미스 → 로컬 AI 계산 후 `savePuzzleCache` 저장
- prefetch 실패 → 저장 없이 로컬 AI로 fallback
- 재시도 시 Board 리마운트로 prefetch 상태 초기화
- `LOCAL_ONLY` 벤치마크 모드에서는 prefetch 미발생